### PR TITLE
Modifications necessary to get compilation to succeed on arm64

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -49,6 +49,7 @@
 #include <linux/icmpv6.h>
 #include <net/ndisc.h>
 #include <net/checksum.h>
+#include <net/ip6_checksum.h>
 #endif
 #endif
 

--- a/core/rtw_ieee80211.c
+++ b/core/rtw_ieee80211.c
@@ -2218,3 +2218,19 @@ const char *action_public_str(u8 action)
 	return _action_public_str[action];
 }
 
+int is_multicast_mac_addr(const u8 *addr)
+{
+	return ((addr[0] != 0xff) && (0x01 & addr[0]));
+}
+
+int is_broadcast_mac_addr(const u8 *addr)
+{
+	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
+		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
+}
+
+int is_zero_mac_addr(const u8 *addr)
+{
+	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
+		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));
+}

--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -1308,29 +1308,11 @@ enum ieee80211_state {
 #define IP_FMT "%d.%d.%d.%d"
 #define IP_ARG(x) ((u8*)(x))[0],((u8*)(x))[1],((u8*)(x))[2],((u8*)(x))[3]
 
-#ifdef PLATFORM_FREEBSD //Baron change func to macro
-#define is_multicast_mac_addr(Addr) ((((Addr[0]) & 0x01) == 0x01) && ((Addr[0]) != 0xff))
-#define is_broadcast_mac_addr(Addr) ((((Addr[0]) & 0xff) == 0xff) && (((Addr[1]) & 0xff) == 0xff) && \
-(((Addr[2]) & 0xff) == 0xff) && (((Addr[3]) & 0xff) == 0xff) && (((Addr[4]) & 0xff) == 0xff) && \
-(((Addr[5]) & 0xff) == 0xff))
-#else
-extern __inline int is_multicast_mac_addr(const u8 *addr)
-{
-        return ((addr[0] != 0xff) && (0x01 & addr[0]));
-}
+extern int is_multicast_mac_addr(const u8 *addr);
 
-extern __inline int is_broadcast_mac_addr(const u8 *addr)
-{
-	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
-		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
-}
+extern int is_broadcast_mac_addr(const u8 *addr);
 
-extern __inline int is_zero_mac_addr(const u8 *addr)
-{
-	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
-		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));
-}
-#endif //PLATFORM_FREEBSD
+extern int is_zero_mac_addr(const u8 *addr);
 
 #define CFG_IEEE80211_RESERVE_FCS (1<<0)
 #define CFG_IEEE80211_COMPUTE_FCS (1<<1)


### PR DESCRIPTION
I have an odroid c2 with ubuntu 16.04 and kernel 3.14.29-29

The changes in this merge request along with the change listed below are necessary to get this to compile with
```
ARCH=arm64 make
```

I modified /usr/src/linux-headers-3.14.29-29/arch/arm64/include/asm/xen/hypervisor.h commenting out the include that referenced hypervisor.h and adding in what should have been in the contents of the missing file.
```
//#include <../../arm/include/asm/xen/hypervisor.h>
#ifndef _ASM_ARM_XEN_HYPERVISOR_H
#define _ASM_ARM_XEN_HYPERVISOR_H

extern struct shared_info *HYPERVISOR_shared_info;
extern struct start_info *xen_start_info;

/* Lazy mode for batching updates / context switch */
enum paravirt_lazy_mode {
    PARAVIRT_LAZY_NONE,
    PARAVIRT_LAZY_MMU,
    PARAVIRT_LAZY_CPU,
};

static inline enum paravirt_lazy_mode paravirt_get_lazy_mode(void)
{
    return PARAVIRT_LAZY_NONE;
}

extern struct dma_map_ops *xen_dma_ops;

#endif /* _ASM_ARM_XEN_HYPERVISOR_H */
```
