### PR TITLE
corrected interface name

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -725,9 +725,15 @@ static const struct net_device_ops rtw_netdev_ops = {
 };
 #endif
 
+static const struct device_type wlan_type = {
+	.name = "wlan",
+};
+
 int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname)
 {
-	_adapter *padapter = rtw_netdev_priv(pnetdev);
+	_adapter *padapter;
+	pnetdev->dev.type = &wlan_type;
+	padapter = rtw_netdev_priv(pnetdev);
 
 #ifdef CONFIG_EASY_REPLACEMENT
 	struct net_device	*TargetNetdev = NULL;


### PR DESCRIPTION
Patch similar to this https://github.com/pvaret/rtl8192cu-fixes/commit/0c0350fb5a180c67b7b91e07d7a18fa43c5721ab as pointed out here https://bbs.archlinux.org/viewtopic.php?pid=1510025#p1510025 for solving the problem with the interface name being enp* instead of wlp*.