### PR TITLE
Edit dkms.conf to use correct kernel version

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -4,6 +4,6 @@ BUILT_MODULE_NAME="8192eu"
 DEST_MODULE_LOCATION="/kernel/drivers/net/wireless/"
 REMAKE_INITRD="yes"
 AUTOINSTALL="yes"
-MAKE="'make' all"
+MAKE="'make' all KVER=${kernelver}"
 CLEAN="make clean"
 


### PR DESCRIPTION
I have a TP-LINK TL-WN823N(EU) Mini Wireless USB Adapter which I was using with these drivers. It was working on kernel versions <=4.4.0-59-generic. It stopped working after a kernel upgrade.

According to this http://askubuntu.com/a/832372/634049, the problem is with the `dkms.conf`. After this and purging/reinstalling this driver to dkms change, it is now working. (4.4.0-71-generic)