### PR TITLE
Disable debug logging by default.

### DIFF
--- a/include/autoconf.h
+++ b/include/autoconf.h
@@ -371,7 +371,7 @@
  */
 #define DBG	1
 
-#define CONFIG_DEBUG /* DBG_871X, etc... */
+//#define CONFIG_DEBUG /* DBG_871X, etc... */
 //#define CONFIG_DEBUG_RTL871X /* RT_TRACE, RT_PRINT_DATA, _func_enter_, _func_exit_ */
 
 #define CONFIG_PROC_DEBUG


### PR DESCRIPTION
As discussed in #9, the default logging of this driver is very verbose.

This change disables the configuration responsible for verbose logging.