### PR TITLE
Fix compilation for ARM64 arch

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -49,6 +49,7 @@
 #include <linux/icmpv6.h>
 #include <net/ndisc.h>
 #include <net/checksum.h>
+#include <net/ip6_checksum.h>
 #endif
 #endif
 


### PR DESCRIPTION
The kernel module failed to build
on arm64 platform. Other platforms like x86 can build without problem
because the csum_ipv6_magic function are defined in arch specific
asm/checksum.h, which is missing on arm64 platform.

Same patch is used on some projects that use ARM64 like [LibreElec](https://github.com/LibreELEC/LibreELEC.tv/commit/90e51a542adc8509d15a402b8545ce9092805c26)

Similar code also exist on newer versions from realtek, [see v.4.4.1](https://github.com/CGarces/rtl8192eu-linux-driver/blob/v4.4.1/core/rtw_br_ext.c#L51-L55)

This change supersede https://github.com/Mange/rtl8192eu-linux-driver/pull/4