### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+language: c
+compiler: gcc
+sudo: required
+
+before_install:
+  - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
+  - export KVER_BUILD=$( echo $ALL_DEB | grep -o '[a-z0-9]*\.[0-9]*\_all\.deb' | cut -d '.' -f 1)
+  - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
+  - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
+  - sudo dpkg -i *.deb
+
+script:
+  - gcc --version
+  - make CC=$COMPILER KVER=$KVER-$KVER_BUILD-generic
+
+env:
+  global:
+    - KERNEL_URL=http://kernel.ubuntu.com/~kernel-ppa/mainline/
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=4.13.1
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+      env: COMPILER=gcc-6 KVER=4.13.1
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+      env: COMPILER=gcc-7 KVER=4.13.1
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=4.4.87
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+      env: COMPILER=gcc-4.9 KVER=3.16.47


### PR DESCRIPTION
Hi @Mange 

I have started this change just as a prof of concept just to check some Travis CI features.

But I think that is good enough to send it as PR.

Travis CI will try to compile the module with several combinations of kernel and gcc versions, after each commit or PR.

Right now it test:

- Kernel 4.13.1 & gcc-5
- Kernel 4.13.1 & gcc-6
- Kernel 4.4.87 & gcc-5
- Kernel 3.16.47 & gcc-4.9

My idea is maintain the file to test the build with le lastest versions of kernels and compilers just changing some lines of the `.travis.yml` file.

To use this PR

1. Activate Travis CI at the [marketplace](https://github.com/marketplace/travis-ci) 
2. Enable the repository in the Travis CI configuration.
3. Accept this PR.
