### PR TITLE
Add support for kernel 4.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ sudo: required
 
 before_install:
   - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
-  - export KVER_BUILD=$( echo $ALL_DEB | grep -o '[a-z0-9]*\.[0-9]*\_all\.deb' | cut -d '.' -f 1)
+  - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
   - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
   - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
   - sudo dpkg -i *.deb
 
 script:
   - gcc --version
-  - make CC=$COMPILER KVER=$KVER-$KVER_BUILD-generic
+  - make CC=$COMPILER KVER=$KVER_BUILD-generic
 
 env:
   global:
@@ -26,7 +26,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-5
-      env: COMPILER=gcc-5 KVER=4.13.1
+      env: COMPILER=gcc-5 KVER=4.14
     - compiler: gcc
       addons:
         apt:
@@ -34,7 +34,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-6
-      env: COMPILER=gcc-6 KVER=4.13.1
+      env: COMPILER=gcc-6 KVER=4.14
     - compiler: gcc
       addons:
         apt:
@@ -42,7 +42,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-7
-      env: COMPILER=gcc-7 KVER=4.13.1
+      env: COMPILER=gcc-7 KVER=4.14
     - compiler: gcc
       addons:
         apt:
@@ -50,7 +50,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-5
-      env: COMPILER=gcc-5 KVER=4.4.87
+      env: COMPILER=gcc-5 KVER=4.4.97
     - compiler: gcc
       addons:
         apt:
@@ -58,4 +58,12 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-4.9
-      env: COMPILER=gcc-4.9 KVER=3.16.47
+      env: COMPILER=gcc-4.9 KVER=3.16.50
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+      env: COMPILER=gcc-5 KVER=3.14.79

--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -1619,7 +1619,11 @@ u32 rtw_read_efuse_from_file(const char *path, u8 *buf)
 	set_fs(KERNEL_DS);
 
 	for (i = 0 ; i < HWSET_MAX_SIZE ; i++) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+		kernel_read(fp, temp, 2, &pos);
+#else
 		vfs_read(fp, temp, 2, &pos);
+#endif
 		if (sscanf(temp, "%hhx", &buf[i]) != 1) {
 			if (0)
 				DBG_871X_LEVEL(_drv_err_, "%s sscanf fail\n", __func__);
@@ -1627,10 +1631,18 @@ u32 rtw_read_efuse_from_file(const char *path, u8 *buf)
 		}
 		if ((i % EFUSE_FILE_COLUMN_NUM) == (EFUSE_FILE_COLUMN_NUM - 1)) {
 			/* Filter the lates space char. */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+			kernel_read(fp, temp, 1, &pos);
+#else
 			vfs_read(fp, temp, 1, &pos);
+#endif
 			if (strchr(temp, ' ') == NULL) {
 				pos--;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+				kernel_read(fp, temp, 2, &pos);
+#else
 				vfs_read(fp, temp, 2, &pos);
+#endif
 			}
 		} else {
 			pos += 1; /* Filter the space character */
@@ -1687,7 +1699,11 @@ u32 rtw_read_macaddr_from_file(const char *path, u8 *buf)
 	fs = get_fs();
 	set_fs(KERNEL_DS);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+	kernel_read(fp, source_addr, 18, &pos);
+#else
 	vfs_read(fp, source_addr, 18, &pos);
+#endif
 	source_addr[17] = ':';
 
 	head = end = source_addr;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4559,7 +4559,11 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t* ssid,
 	source = rtw_zmalloc(2048);
 
 	if (source != NULL) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+		len = kernel_read(fp, source, len, &pos);
+#else
 		len = vfs_read(fp, source, len, &pos);
+#endif
 		rtw_parse_cipher_list(nlo_info, source);
 		rtw_mfree(source, 2048);
 	}

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1911,7 +1911,11 @@ static int readFile(struct file *fp,char *buf,int len)
 
 	while(sum<len) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
+		rlen = kernel_read(fp, buf+sum, len-sum, &fp->f_pos);
+#else
 		rlen = __vfs_read(fp, buf+sum, len-sum, &fp->f_pos);
+#endif
 #else
 		rlen = fp->f_op->read(fp, buf+sum, len-sum, &fp->f_pos);
 #endif

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1910,14 +1910,12 @@ static int readFile(struct file *fp,char *buf,int len)
 		return -EPERM;
 
 	while(sum<len) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0))
-		rlen = kernel_read(fp, buf+sum, len-sum, &fp->f_pos);
+		rlen = kernel_read(fp, buf + sum, len - sum, &fp->f_pos);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+		rlen = __vfs_read(fp, buf + sum, len - sum, &fp->f_pos);
 #else
-		rlen = __vfs_read(fp, buf+sum, len-sum, &fp->f_pos);
-#endif
-#else
-		rlen = fp->f_op->read(fp, buf+sum, len-sum, &fp->f_pos);
+		rlen = fp->f_op->read(fp, buf + sum, len - sum, &fp->f_pos);
 #endif
 		if(rlen>0)
 			sum+=rlen;


### PR DESCRIPTION
'vfs_read' is no longer exported (see kernel commit
https://github.com/torvalds/linux/commit/bd8df82be6).

I'm not very experienced in kernel hacking, so reviews and comments are very welcome.

Verified on Linux 4.14rc6.