### PR TITLE
Add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,28 +32,46 @@ generating kernel modules from out-of-tree kernel sources. It can be used to
 install/uninstall kernel modules, and the module will be automatically rebuilt
 from source when the kernel is upgraded (for example using your package manager).
 
-1. Install DKMS and other required tools
+#### Install DKMS and other required tools
 
-    * for normal Linux systems
-
-    ```shell
-    $ sudo apt-get install git linux-headers-generic build-essential dkms
-    ```
-
-    * for Raspberry Pi
+* for normal Linux systems
 
     ```shell
-    $ sudo apt-get install git raspberrypi-kernel-headers build-essential dkms
+    $ sudo apt install git linux-headers-generic build-essential dkms
     ```
 
-2. Add the driver to DKMS. This will copy the source to a system directory so
+* for Raspberry Pi
+
+    ```shell
+    $ sudo apt install git raspberrypi-kernel-headers build-essential dkms
+    ```
+
+#### Automatic install (x86/PC versions)
+
+* Download install script:
+
+    ```shell
+    $ wget -P /tmp https://github.com/Mange/rtl8192eu-linux-driver/raw/realtek-4.4.x/install.sh
+    ```
+
+* Review install script at `/tmp/install.sh`
+
+* Run it:
+
+    ```shell
+    $ bash /tmp/install.sh
+    ```
+
+#### Manual install
+
+1. Add the driver to DKMS. This will copy the source to a system directory so
 that it can used to rebuild the module on kernel upgrades.
 
     ```shell
     $ sudo dkms add .
     ```
 
-3. Build and install the driver.
+2. Build and install the driver.
 
     ```shell
     $ sudo dkms install rtl8192eu/1.0
@@ -76,14 +94,15 @@ CONFIG_PLATFORM_ARM_RPI = y
 # sudo modprobe -a 8192eu
 ```
 
-4. Check that your kernel has loaded the right module:
+3. Check that your kernel has loaded the right module:
  
     ```shell
-        $ lshw -c network
+    $ lshw -c network
     ```
    
 You should see the line ```driver=8192eu```
-    
+
+#### Uninstall
 If you wish to uninstall the driver at a later point, use
 _sudo dkms uninstall rtl8192eu/1.0_. To completely remove the driver from DKMS use
 _sudo dkms remove rtl8192eu/1.0 --all_.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+
+for c in "sudo" "mktemp" "git" "dkms"; do
+    command -v $c >/dev/null 2>&1 || { echo >&2 "Script uses $c, but it's not installed. Aborting."; exit 1; }
+done
+
+sudo echo # pre-authorise sudo
+
+cd $(mktemp -d)
+
+git clone --depth 1 https://github.com/Mange/rtl8192eu-linux-driver.git
+cd rtl8192eu-linux-driver
+
+sudo dkms remove rtl8192eu/1.0 --all
+sudo dkms add .
+sudo dkms install rtl8192eu/1.0
+sudo modprobe 8192eu
+
+cd ..
+rm -rf $(pwd)
+
+echo "blacklist wl" | sudo tee /etc/modprobe.d/blacklist-wl.conf
+echo "blacklist rtl8xxxu" | sudo tee /etc/modprobe.d/blacklist-rtl8xxxu.conf


### PR DESCRIPTION
This simple install script probably covers needs of most users, so they could just wget it, inspect and run, instead of manually entering install commands.

Module blacklisting could be made optional with `read -p "Blacklist module X? (y/n) " ...`, not sure if this additional user interaction is worth it, so right now `wl` and `rtl8xxxu` modules are blacklisted by default.