### PR TITLE
Fixes for 4.19-rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ before_install:
   - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
   - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
   - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
+  - sudo apt-get update
+  - sudo apt-get install -y dpkg  # to upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
   - sudo dpkg -i *.deb
 
 script:
-  - gcc --version
   - make CC=$COMPILER KVER=$KVER_BUILD-generic
 
 env:
@@ -24,28 +25,34 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-5
             - libelf-dev
-      env: COMPILER=gcc-5 KVER=4.15-rc6
+            - libssl1.1
+      env: COMPILER=gcc-5 KVER=4.19-rc1
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-6
             - libelf-dev
-      env: COMPILER=gcc-6 KVER=4.15-rc6
+            - libssl1.1
+      env: COMPILER=gcc-6 KVER=4.19-rc1
     - compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - gcc-7
             - libelf-dev
-      env: COMPILER=gcc-7 KVER=4.15-rc6
+            - libssl1.1
+      env: COMPILER=gcc-7 KVER=4.19-rc1
     - compiler: gcc
       addons:
         apt:

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1016,7 +1016,9 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 #define IEEE80211_MAX_AMPDU_BUF 0x40
+#endif
 
 
 /* Spatial Multiplexing Power Save Modes */

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -929,12 +929,13 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
  
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0) 	
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+				, struct net_device *sb_dev
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
 				, void *accel_priv
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) 
 				, select_queue_fallback_t fallback
-#endif
-
 #endif
 )
 {


### PR DESCRIPTION
Build tested (LibreELEC 9.0), but not run-time tested (no hardware).