### PR TITLE
kernel 5.0: Remove 'type' argument from access_ok() function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
             - gcc-5
             - libelf-dev
             - libssl1.1
-      env: COMPILER=gcc-5 KVER=4.19-rc1
+      env: COMPILER=gcc-5 KVER=5.0-rc1
     - compiler: gcc
       addons:
         apt:
@@ -41,7 +41,7 @@ matrix:
             - gcc-6
             - libelf-dev
             - libssl1.1
-      env: COMPILER=gcc-6 KVER=4.19-rc1
+      env: COMPILER=gcc-6 KVER=5.0-rc1
     - compiler: gcc
       addons:
         apt:
@@ -52,7 +52,7 @@ matrix:
             - gcc-7
             - libelf-dev
             - libssl1.1
-      env: COMPILER=gcc-7 KVER=4.19-rc1
+      env: COMPILER=gcc-7 KVER=5.0-rc1
     - compiler: gcc
       addons:
         apt:

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -626,7 +626,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)){
+#else
 	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)){
+#endif
 	 	DBG_871X("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;


### PR DESCRIPTION
See: https://github.com/torvalds/linux/commit/96d4f267e40f9509e8a66e2b39e8b95655617693