### PR TITLE
Cleanup the compilation warnings

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -12411,29 +12411,37 @@ void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 	/*
 		IOT issue,occur Broadcom ap(Buffalo WZR-D1800H,Netgear R6300).
 		AP is originator.AP does not transmit unicast packets when STA response its BAR.
-		This case probably occur ap issue BAR after AP builds BA. 
-				
+		This case probably occur ap issue BAR after AP builds BA.
+
 		Follow 802.11 spec, STA shall maintain an inactivity timer for every negotiated Block Ack setup.
 		The inactivity timer is not reset when MPDUs corresponding to other TIDs are received.
 	*/
 	if (pmlmeinfo->assoc_AP_vendor == HT_IOT_PEER_BROADCOM) {
-		for (i = 0; i < TID_NUM ; i++) {				
-			if ((psta->recvreorder_ctrl[i].enable) && 
-                        (sta_rx_data_qos_pkts(psta, i) == sta_last_rx_data_qos_pkts(psta, i)) ) {			
-					if (_TRUE == rtw_inc_and_chk_continual_no_rx_packet(psta, i)) {					
-						/* send a DELBA frame to the peer STA with the Reason Code field set to TIMEOUT */		
-						if (!from_timer)
-							ret = issue_del_ba_ex(padapter, psta->hwaddr, i, 39, 0, 3, 1);
-						else
-							issue_del_ba(padapter,  psta->hwaddr, i, 39, 0);							
-							psta->recvreorder_ctrl[i].enable = _FALSE;
-						if (ret != _FAIL)
-							psta->recvreorder_ctrl[i].ampdu_size = RX_AMPDU_SIZE_INVALID;
-							rtw_reset_continual_no_rx_packet(psta, i);
-					}				
-			}else{   
+		for (i = 0; i < TID_NUM ; i++) {
+			if ((psta->recvreorder_ctrl[i].enable) &&
+                        (sta_rx_data_qos_pkts(psta, i) == sta_last_rx_data_qos_pkts(psta, i)) ) {
+				if (_TRUE == rtw_inc_and_chk_continual_no_rx_packet(psta, i)) {
+					/* send a DELBA frame to the peer STA with the Reason Code field set to TIMEOUT */
+					if (!from_timer)
+					{
+						ret = issue_del_ba_ex(padapter, psta->hwaddr, i, 39, 0, 3, 1);
+					}
+					else
+					{
+						issue_del_ba(padapter,  psta->hwaddr, i, 39, 0);
+					}
+					psta->recvreorder_ctrl[i].enable = _FALSE;
+					if (ret != _FAIL)
+					{
+						psta->recvreorder_ctrl[i].ampdu_size = RX_AMPDU_SIZE_INVALID;
+					}
+					rtw_reset_continual_no_rx_packet(psta, i);
+				}
+			}
+			else
+			{
 				/* The inactivity timer is reset when MPDUs to the TID is received. */
-				rtw_reset_continual_no_rx_packet(psta, i);	
+				rtw_reset_continual_no_rx_packet(psta, i);
 			}
 		}
 	}

--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -1482,8 +1482,8 @@ static sint aes_cipher(u8 *key, uint	hdrlen,
 //	uint	offset = 0;
 	uint	frtype  = GetFrameType(pframe);
 	uint	frsubtype  = GetFrameSubType(pframe);
-	
-_func_enter_;		
+
+_func_enter_;
 	frsubtype=frsubtype>>4;
 
 
@@ -1506,8 +1506,7 @@ _func_enter_;
 		((frtype|frsubtype) == WIFI_DATA_CFACKPOLL))
 		{
 			qc_exists = 1;
-					if(hdrlen !=  WLAN_HDR_A3_QOS_LEN){
-				 
+			if(hdrlen !=  WLAN_HDR_A3_QOS_LEN){
 					hdrlen += 2;
 			}
 		}
@@ -1519,8 +1518,7 @@ _func_enter_;
 		(frsubtype == 0x0b)))
 		{
 			if(hdrlen !=  WLAN_HDR_A3_QOS_LEN){
-				 
-					hdrlen += 2;
+				hdrlen += 2;
 			}
 			qc_exists = 1;
 		}
@@ -1533,7 +1531,7 @@ _func_enter_;
 	pn_vector[3]=pframe[hdrlen+5];
 	pn_vector[4]=pframe[hdrlen+6];
 	pn_vector[5]=pframe[hdrlen+7];
-	
+
 	construct_mic_iv(
                         mic_iv,
                         qc_exists,
@@ -1596,9 +1594,11 @@ _func_enter_;
 
     /* Insert MIC into payload */
     for (j = 0; j < 8; j++)
-    	pframe[payload_index+j] = mic[j];	//message[payload_index+j] = mic[j];
+    {
+        pframe[payload_index+j] = mic[j];	//message[payload_index+j] = mic[j];
+    }
 
-	payload_index = hdrlen + 8;
+    payload_index = hdrlen + 8;
 	for (i=0; i< num_blocks; i++)
     {
         construct_ctr_preload(
@@ -1654,7 +1654,7 @@ _func_enter_;
     aes128k128d(key, ctr_preload, aes_out);
     bitwise_xor(aes_out, padded_buffer, chain_buffer);
     for (j=0; j<8;j++) pframe[payload_index++] = chain_buffer[j];//for (j=0; j<8;j++) message[payload_index++] = chain_buffer[j];
-_func_exit_;		
+_func_exit_;
 	return _SUCCESS;
 }
 
@@ -1982,9 +1982,11 @@ _func_enter_;
 
     /* Insert MIC into payload */
     for (j = 0; j < 8; j++)
-    	message[payload_index+j] = mic[j];
+    {
+        message[payload_index+j] = mic[j];
+    }
 
-	payload_index = hdrlen + 8;
+    payload_index = hdrlen + 8;
 	for (i=0; i< num_blocks; i++)
     {
         construct_ctr_preload(

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -31,14 +31,18 @@
 #define STATION_INFO_ASSOC_REQ_IES	0
 #endif /* Linux kernel >= 4.0.0 */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
-enum ieee80211_band {
-        IEEE80211_BAND_2GHZ = NL80211_BAND_2GHZ,
-        IEEE80211_BAND_5GHZ = NL80211_BAND_5GHZ,
-        IEEE80211_BAND_60GHZ = NL80211_BAND_60GHZ,
 
-        /* keep last */
-        IEEE80211_NUM_BANDS
-};
+// Creating your own enum to compare with another one is not very accurate.
+// I have rewritten this through defines, so that it means the same, while keeping compilers happy.
+#define ieee80211_band nl80211_band
+#define IEEE80211_BAND_2GHZ NL80211_BAND_2GHZ
+#define IEEE80211_BAND_5GHZ NL80211_BAND_5GHZ
+#define IEEE80211_BAND_60GHZ NL80211_BAND_60GHZ
+
+// this was not used in the entire *.c file, so I just safely drop it
+/* keep last */
+// IEEE80211_NUM_BANDS
+
 #endif /* Linux kernel >= 4.7.0 */
 
 #include <rtw_wifi_regd.h>
@@ -224,9 +228,7 @@ void rtw_5g_rates_init(struct ieee80211_rate *rates)
 	);
 }
 
-struct ieee80211_supported_band *rtw_spt_band_alloc(
-	enum ieee80211_band band
-	)
+struct ieee80211_supported_band *rtw_spt_band_alloc(enum ieee80211_band band)
 {
 	struct ieee80211_supported_band *spt_band = NULL;
 	int n_channels, n_bitrates;


### PR DESCRIPTION
This pull request corrects the indentation which misleads the compiler (and, in one case, humans).

I have also dropped the `enum ieee80211_band`, which is defined when the kernel version is new enough (so that it has `enum nl80211_band` instead). This hack produces a couple of enum comparison warnings. Fortunately, making a bunch of defines instead of synthesizing a new enum (i) is better in my opinion, (ii) is better readable by the compiler.

Spurious whitespace cleanup has also happened in few places.