### PR TITLE
Enable power management (hopefully).

### DIFF
--- a/hal/rtl8192e/rtl8192e_dm.c
+++ b/hal/rtl8192e/rtl8192e_dm.c
@@ -460,16 +460,16 @@ void rtl8192e_init_dm_priv(IN PADAPTER Adapter)
 	PDM_ODM_T 		podmpriv = &pHalData->odmpriv;
 	//_rtw_spinlock_init(&(pHalData->odm_stainfo_lock));
 	Init_ODM_ComInfo_8192e(Adapter);
-	ODM_InitAllTimers(podmpriv );	
+	ODM_InitAllTimers(podmpriv);
 	PHYDM_InitDebugSetting(podmpriv);
-
+	pHalData->CurrentTxPwrIdx = 20;
 }
 
 void rtl8192e_deinit_dm_priv(IN PADAPTER Adapter)
 {
 	PHAL_DATA_TYPE	pHalData = GET_HAL_DATA(Adapter);
 	PDM_ODM_T 		podmpriv = &pHalData->odmpriv;
-	//_rtw_spinlock_free(&pHalData->odm_stainfo_lock);		
+	//_rtw_spinlock_free(&pHalData->odm_stainfo_lock);
 	ODM_CancelAllTimers(podmpriv);
 }
 

--- a/include/hal_data.h
+++ b/include/hal_data.h
@@ -402,6 +402,7 @@ typedef struct hal_com_data
 	u8	CurrentOfdm24GTxPwrIdx;
 	u8	CurrentBW2024GTxPwrIdx;
 	u8	CurrentBW4024GTxPwrIdx;
+	u8	CurrentTxPwrIdx;
 	
 	// Read/write are allow for following hardware information variables	
 	u8	pwrGroupCnt;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -46,6 +46,7 @@
 #endif /* Linux kernel >= 4.7.0 */
 
 #include <rtw_wifi_regd.h>
+#include <hal_data.h>
 
 #define RTW_MAX_MGMT_TX_CNT (8)
 #define RTW_MAX_MGMT_TX_MS_GAS (500)
@@ -3464,39 +3465,28 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 	struct wireless_dev *wdev,
 #endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,36)) || defined(COMPAT_KERNEL_RELEASE)
-	enum nl80211_tx_power_setting type, int mbm)
+	enum nl80211_tx_power_setting type,
 #else
-	enum tx_power_setting type, int dbm)
+	enum tx_power_setting type,
 #endif
+	int value)
 {
-#if 0
-	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
-	int ret;
+	_adapter *padapter = wiphy_to_adapter(wiphy);
+	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(padapter);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,36)) || defined(COMPAT_KERNEL_RELEASE)
+	value /= 100;
+#endif
 
-	switch (type) {
-	case NL80211_TX_POWER_AUTOMATIC:
+	if (value < 0)	value = 0;
+	if (value > 20)	value = 20;
+
+	if (type == NL80211_TX_POWER_FIXED) {
+		pHalData->CurrentTxPwrIdx = value;
+		rtw_hal_set_tx_power_level(padapter, pHalData->CurrentChannel);
 		return 0;
-	case NL80211_TX_POWER_FIXED:
-		if (mbm < 0 || (mbm % 100))
-			return -EOPNOTSUPP;
-
-		if (!test_bit(IWM_STATUS_READY, &iwm->status))
-			return 0;
-
-		ret = iwm_umac_set_config_fix(iwm, UMAC_PARAM_TBL_CFG_FIX,
-					      CFG_TX_PWR_LIMIT_USR,
-					      MBM_TO_DBM(mbm) * 2);
-		if (ret < 0)
-			return ret;
-
-		return iwm_tx_power_trigger(iwm);
-	default:
-		IWM_ERR(iwm, "Unsupported power type: %d\n", type);
+	} else {
 		return -EOPNOTSUPP;
 	}
-#endif
-	DBG_8192C("%s\n", __func__);
-	return 0;
 }
 
 static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
@@ -3505,10 +3495,9 @@ static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
 #endif
 	int *dbm)
 {
-	DBG_8192C("%s\n", __func__);
-
-	*dbm = (12);
-	
+	_adapter *padapter = wiphy_to_adapter(wiphy);
+	HAL_DATA_TYPE   *pHalData = GET_HAL_DATA(padapter);
+	*dbm = pHalData->CurrentTxPwrIdx;
 	return 0;
 }
 


### PR DESCRIPTION
By "hopefully" I mean that it does not crash, `iwconfig` now accepts `txpower` changes, and the value seems to be promoted in a reasonable way. However, I have no hardware to tell whether the output power actually changes.

Most changes are adapted from https://github.com/astsam/rtl8812au,
with the exception that I set a thing, which appears to be a power limit, to 20 instead of 18.
I have no idea whether this is a right thing to do, but my wireless card, with a maximum output power of 20dbm, does not object.

A few `#if 0`-s and some unnecessary trailing whitespace, which were close to the edited regions, were also removed. 