### PR TITLE
Add VID/PID to support Mercusys MW300UH adapter

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -197,8 +197,8 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x2019, 0xab33),.driver_info = RTL8192E}, /* PLANEX - GW-300S Katana */
 	/*=== Customer ID ===*/
 	{USB_DEVICE(0x2001, 0x3319),.driver_info = RTL8192E}, /* D-Link - DWA-131 */
-        {USB_DEVICE(0x2c4e, 0x0100),.driver_info = RTL8192E}, /* Mercusys MW300UM */
-		{USB_DEVICE(0x2c4e, 0x0104),.driver_info = RTL8192E}, /* Mercusys MW300UH */
+	{USB_DEVICE(0x2c4e, 0x0100),.driver_info = RTL8192E}, /* Mercusys MW300UM */
+	{USB_DEVICE(0x2c4e, 0x0104),.driver_info = RTL8192E}, /* Mercusys MW300UH */
 #endif
 
 #ifdef CONFIG_RTL8723B

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -198,6 +198,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	/*=== Customer ID ===*/
 	{USB_DEVICE(0x2001, 0x3319),.driver_info = RTL8192E}, /* D-Link - DWA-131 */
         {USB_DEVICE(0x2c4e, 0x0100),.driver_info = RTL8192E}, /* Mercusys MW300UM */
+		{USB_DEVICE(0x2c4e, 0x0104),.driver_info = RTL8192E}, /* Mercusys MW300UH */
 #endif
 
 #ifdef CONFIG_RTL8723B


### PR DESCRIPTION
I bought Mercusys MW300UH adapter and lost 2 days in searching of solution to make it work. Finally I added this line to driver and got it. It contains MW300UH VID/PID from my lsusb.