### PR TITLE
linux-5.3: adding vendor command policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - libssl1.1
-      env: COMPILER=gcc-5 KVER=5.2-rc2
+      env: COMPILER=gcc-5 KVER=5.3
     - compiler: gcc
       addons:
         apt:
@@ -35,7 +35,7 @@ matrix:
           packages:
             - gcc-6
             - libssl1.1
-      env: COMPILER=gcc-6 KVER=5.2-rc2
+      env: COMPILER=gcc-6 KVER=5.3
     - compiler: gcc
       addons:
         apt:
@@ -45,7 +45,7 @@ matrix:
           packages:
             - gcc-7
             - libssl1.1
-      env: COMPILER=gcc-7 KVER=5.2-rc2
+      env: COMPILER=gcc-7 KVER=5.3
     - compiler: gcc
       addons:
         apt:
@@ -53,7 +53,7 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - libssl1.1
-      env: COMPILER=gcc-5 KVER=4.19.45
+      env: COMPILER=gcc-5 KVER=4.19.74
     - compiler: gcc
       addons:
         apt:
@@ -63,7 +63,7 @@ matrix:
           packages:
             - gcc-6
             - libssl1.1
-      env: COMPILER=gcc-6 KVER=4.19.45
+      env: COMPILER=gcc-6 KVER=4.19.74
     - compiler: gcc
       addons:
         apt:
@@ -73,4 +73,4 @@ matrix:
           packages:
             - gcc-7
             - libssl1.1
-      env: COMPILER=gcc-7 KVER=4.19.45
+      env: COMPILER=gcc-7 KVER=4.19.74

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - libssl1.1
-      env: COMPILER=gcc-5 KVER=5.2-rc2
+      env: COMPILER=gcc-5 KVER=5.3-rc5
     - compiler: gcc
       addons:
         apt:
@@ -35,7 +35,7 @@ matrix:
           packages:
             - gcc-6
             - libssl1.1
-      env: COMPILER=gcc-6 KVER=5.2-rc2
+      env: COMPILER=gcc-6 KVER=5.3-rc5
     - compiler: gcc
       addons:
         apt:
@@ -45,7 +45,7 @@ matrix:
           packages:
             - gcc-7
             - libssl1.1
-      env: COMPILER=gcc-7 KVER=5.2-rc2
+      env: COMPILER=gcc-7 KVER=5.3-rc5
     - compiler: gcc
       addons:
         apt:
@@ -53,7 +53,7 @@ matrix:
             - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
             - libssl1.1
-      env: COMPILER=gcc-5 KVER=4.19.45
+      env: COMPILER=gcc-5 KVER=4.19.67
     - compiler: gcc
       addons:
         apt:
@@ -63,7 +63,7 @@ matrix:
           packages:
             - gcc-6
             - libssl1.1
-      env: COMPILER=gcc-6 KVER=4.19.45
+      env: COMPILER=gcc-6 KVER=4.19.67
     - compiler: gcc
       addons:
         apt:
@@ -73,4 +73,4 @@ matrix:
           packages:
             - gcc-7
             - libssl1.1
-      env: COMPILER=gcc-7 KVER=4.19.45
+      env: COMPILER=gcc-7 KVER=4.19.67

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -1172,6 +1172,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = BRCM_VENDOR_SCMD_PRIV_STR
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_priv_string_handler
 	},
 #if defined(GSCAN_SUPPORT) && 0
@@ -1180,6 +1183,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.vendor_id = OUI_GOOGLE,
 			.subcmd = GSCAN_SUBCMD_GET_CAPABILITIES
 		},
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = wl_cfgvendor_gscan_get_capabilities
 	},
@@ -1189,6 +1195,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_SET_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_set_scan_cfg
 	},
 	{
@@ -1197,6 +1206,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_SET_SCAN_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_set_batch_scan_cfg
 	},
 	{
@@ -1205,6 +1217,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_ENABLE_GSCAN
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_initiate_gscan
 	},
 	{
@@ -1213,6 +1228,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_ENABLE_FULL_SCAN_RESULTS
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_enable_full_scan_result
 	},
 	{
@@ -1221,6 +1239,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_SET_HOTLIST
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_hotlist_cfg
 	},
 	{
@@ -1229,6 +1250,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_SET_SIGNIFICANT_CHANGE_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_significant_change_cfg
 	},
 	{
@@ -1237,6 +1261,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_GET_SCAN_RESULTS
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_gscan_get_batch_results
 	},
 	{
@@ -1245,6 +1272,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = GSCAN_SUBCMD_GET_CHANNEL_LIST
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_gscan_get_channel_list
 	},
 #endif /* GSCAN_SUPPORT */
@@ -1255,6 +1285,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = RTT_SUBCMD_SET_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_rtt_set_config
 	},
 	{
@@ -1263,6 +1296,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = RTT_SUBCMD_CANCEL_CONFIG
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_rtt_cancel_config
 	},
 	{
@@ -1271,6 +1307,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = RTT_SUBCMD_GETCAPABILITY
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = wl_cfgvendor_rtt_get_capability
 	},
 #endif /* RTT_SUPPORT */
@@ -1280,6 +1319,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = ANDR_WIFI_SUBCMD_GET_FEATURE_SET
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = rtw_cfgvendor_get_feature_set
 	},
 	{
@@ -1288,6 +1330,9 @@ static const struct wiphy_vendor_command rtw_vendor_cmds [] = {
 			.subcmd = ANDR_WIFI_SUBCMD_GET_FEATURE_SET_MATRIX
 		},
 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
+		.policy = VENDOR_CMD_RAW_DATA,
+#endif
 		.doit = rtw_cfgvendor_get_feature_set_matrix
 	}
 };


### PR DESCRIPTION
Required changes for kernel (>= 5.3.0), see torvalds/linux@901bb98.
Travis CI updated to last mainline and LTS kernel