### PR TITLE
Partially silence driver and make -O2 the default optimization flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 EXTRA_CFLAGS += $(USER_EXTRA_CFLAGS)
-EXTRA_CFLAGS += -O1
+
+# Optimization flags
+#EXTRA_CFLAGS += -O1
+EXTRA_CFLAGS += -O2
 #EXTRA_CFLAGS += -O3
+
+# Compile-time warnings
 #EXTRA_CFLAGS += -Wall
 #EXTRA_CFLAGS += -Wextra
 #EXTRA_CFLAGS += -Werror
 #EXTRA_CFLAGS += -pedantic
 #EXTRA_CFLAGS += -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes
+#EXTRA_CFLAGS += -Wno-uninitialized
+#EXTRA_CFLAGS += -Wno-error=date-time	# Fix compile error on gcc 4.9 and later
 
 EXTRA_CFLAGS += -Wno-unused-variable
 EXTRA_CFLAGS += -Wno-unused-value
@@ -13,12 +20,8 @@ EXTRA_CFLAGS += -Wno-unused-label
 EXTRA_CFLAGS += -Wno-unused-parameter
 EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-unused
-
 EXTRA_CFLAGS += -Wno-date-time
-
-#EXTRA_CFLAGS += -Wno-uninitialized
 EXTRA_CFLAGS += -Wno-incompatible-pointer-types
-#EXTRA_CFLAGS += -Wno-error=date-time	# Fix compile error on gcc 4.9 and later
 
 EXTRA_CFLAGS += -I$(src)/include
 EXTRA_CFLAGS += -I$(src)/hal/phydm
@@ -26,7 +29,9 @@ EXTRA_CFLAGS += -I$(src)/hal/phydm
 EXTRA_LDFLAGS += --strip-debug
 
 CONFIG_AUTOCFG_CP = n
-
+##########################  DEBUG  ############################
+CONFIG_RTW_DEBUG = n
+CONFIG_RTW_LOG_LEVEL = 2
 ########################## WIFI IC ############################
 CONFIG_MULTIDRV = n
 CONFIG_RTL8188E = n


### PR DESCRIPTION
-O2 compiles everything at this point so I figured out why not.
Added debug flags on Makefile to make the driver only output errors. Commenting out the lines in the DEBUG section returns the driver to its default noisy behavior.

Fix https://github.com/Mange/rtl8192eu-linux-driver/issues/79