### PR TITLE
rtl8192eu: Fix driver startup traps in rtw_cfg80211_ch_switch_notify

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -1784,7 +1784,7 @@ chbw_decision:
 				, pdvobj->padapters[i]->mlmeextpriv.cur_channel
 				, pdvobj->padapters[i]->mlmeextpriv.cur_bwmode
 				, pdvobj->padapters[i]->mlmeextpriv.cur_ch_offset
-				, ht_option);
+				, ht_option, 0);
 		}
 	}
 #endif /* defined(CONFIG_IOCTL_CFG80211) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)) */

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -16096,7 +16096,7 @@ void rtw_join_done_chk_ch(_adapter *adapter, int join_res)
 
 						rtw_cfg80211_ch_switch_notify(iface
 							, mlmeext->cur_channel, mlmeext->cur_bwmode, mlmeext->cur_ch_offset
-							, ht_option);
+							, ht_option, 0);
 						#endif
 					}
 				}
@@ -16314,7 +16314,7 @@ exit:
 				the bss freq is updated by channel switch event.
 			*/
 			rtw_cfg80211_ch_switch_notify(adapter,
-				cur_ch, cur_bw, cur_ch_offset, ht_option);
+				cur_ch, cur_bw, cur_ch_offset, ht_option, 1);
 		}
 #endif
 	}

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -424,19 +424,27 @@ bool rtw_cfg80211_allow_ch_switch_notify(_adapter *adapter)
 	return 1;
 }
 
-u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht)
+u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
+	u8 ht, bool started)
 {
 	struct wiphy *wiphy = adapter_to_wiphy(adapter);
 	u8 ret = _SUCCESS;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-	struct cfg80211_chan_def chdef;
-
-	if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
-		goto exit;
+	struct cfg80211_chan_def chdef = {};
 
 	ret = rtw_chbw_to_cfg80211_chan_def(wiphy, &chdef, ch, bw, offset, ht);
 	if (ret != _SUCCESS)
+		goto exit;
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+	if (started) {
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0);
+		goto exit;
+	}
+#endif
+
+	if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
 		goto exit;
 
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);

--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -407,7 +407,7 @@ void rtw_cfg80211_deinit_rfkill(struct wiphy *wiphy);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
-u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht);
+u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 ht, bool started);
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26)) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0))


### PR DESCRIPTION
These changes are a backport of associated newer changes made in the v5.6.4.2 rtl8812au driver, and correct problems in the previous initialization process that caused multiple kernel traps on startup.

See https://github.com/aircrack-ng/rtl8812au/pull/699

Here are the two kernel traps that occur prior to these changes (this is using kernel 5.8.1 on an arm64 board):

    [   11.678495] ------------[ cut here ]------------
    [   11.678549] WARNING: CPU: 0 PID: 482 at net/wireless/nl80211.c:16827 cfg80211_ch_switch_notify+0xac/0xb8 [cfg80211]
    [   11.678552] Modules linked in: zstd zram 8192eu sun8i_codec_analog sun4i_codec sun8i_adda_pr_regmap snd_soc_core cfg80211 snd_pcm_dmaengine snd_pcm lima rfkill snd_timer snd gpu_sched sun4i_gpadc_iio soundcore industrialio sunxi_cedrus(C) videobuf2_dma_contig v4l2_mem2mem videobuf2_memops videobuf2_v4l2 videobuf2_common videodev sun8i_ce crypto_engine mc cpufreq_dt realtek sy8106a_regulator spidev spi_gpio spi_bitbang dwmac_sun8i i2c_mv64xxx mdio_mux
    [   11.678614] CPU: 0 PID: 482 Comm: RTW_CMD_THREAD Tainted: G         C        5.8.1-sunxi64 #trunk
    [   11.678616] Hardware name: FriendlyARM NanoPi NEO Core2 (DT)
    [   11.678621] pstate: 60000005 (nZCv daif -PAN -UAO BTYPE=--)
    [   11.678635] pc : cfg80211_ch_switch_notify+0xac/0xb8 [cfg80211]
    [   11.678795] lr : rtw_cfg80211_ch_switch_notify+0xfc/0x138 [8192eu]
    [   11.678797] sp : ffff8000118bbcb0
    [   11.678799] x29: ffff8000118bbcb0 x28: ffff80001165e0fc
    [   11.678803] x27: ffff80001165db08 x26: 0000000000000000
    [   11.678807] x25: ffff000034a112e0 x24: 0000000000000001
    [   11.678810] x23: 0000000000000000 x22: 000000000000096c
    [   11.678813] x21: ffff00003490a000 x20: ffff000034a11000
    [   11.678817] x19: ffff8000118bbd38 x18: ffff000033df87e8
    [   11.678821] x17: 0000000060175def x16: 000000005f5f696e
    [   11.678824] x15: 00000520dfc4da1c x14: 040001163d000000
    [   11.678827] x13: 0000000000000000 x12: ffff80001165dce2
    [   11.678831] x11: 0000000000000001 x10: ffff80001165d7be
    [   11.678834] x9 : 0000000000000040 x8 : ffff000034a113f8
    [   11.678838] x7 : ffff000034a11418 x6 : 00000000000003e8
    [   11.678841] x5 : ffff000034f9acf8 x4 : ffff000034f9ad18
    [   11.678844] x3 : ffff8000118bbd70 x2 : c32730ff00000000
    [   11.678847] x1 : 0000000000000000 x0 : ffff000034f9ac00
    [   11.678852] Call trace:
    [   11.678871]  cfg80211_ch_switch_notify+0xac/0xb8 [cfg80211]
    [   11.678975]  rtw_cfg80211_ch_switch_notify+0xfc/0x138 [8192eu]
    [   11.679039]  rtw_chk_start_clnt_join+0x68/0x88 [8192eu]
    [   11.679094]  join_cmd_hdl+0x1ec/0x338 [8192eu]
    [   11.679148]  rtw_cmd_thread+0x390/0x3c8 [8192eu]
    [   11.679161]  kthread+0xf8/0x128
    [   11.679169]  ret_from_fork+0x10/0x30
    [   11.679175] ---[ end trace 662dec273b9122c5 ]---
    [   11.679376] ------------[ cut here ]------------
    [   11.679432] WARNING: CPU: 0 PID: 482 at net/wireless/nl80211.c:3301 nl80211_send_chandef+0x178/0x188 [cfg80211]
    [   11.679435] Modules linked in: zstd zram 8192eu sun8i_codec_analog sun4i_codec sun8i_adda_pr_regmap snd_soc_core cfg80211 snd_pcm_dmaengine snd_pcm lima rfkill snd_timer snd gpu_sched sun4i_gpadc_iio soundcore industrialio sunxi_cedrus(C) videobuf2_dma_contig v4l2_mem2mem videobuf2_memops videobuf2_v4l2 videobuf2_common videodev sun8i_ce crypto_engine mc cpufreq_dt realtek sy8106a_regulator spidev spi_gpio spi_bitbang dwmac_sun8i i2c_mv64xxx mdio_mux
    [   11.679493] CPU: 0 PID: 482 Comm: RTW_CMD_THREAD Tainted: G        WC        5.8.1-sunxi64 #trunk
    [   11.679495] Hardware name: FriendlyARM NanoPi NEO Core2 (DT)
    [   11.679500] pstate: 40000005 (nZcv daif -PAN -UAO BTYPE=--)
    [   11.679513] pc : nl80211_send_chandef+0x178/0x188 [cfg80211]
    [   11.679525] lr : nl80211_send_chandef+0x34/0x188 [cfg80211]
    [   11.679527] sp : ffff8000118bbc00
    [   11.679529] x29: ffff8000118bbc00 x28: ffff80001165e0fc
    [   11.679533] x27: ffff800008ea1d70 x26: 0000000000000000
    [   11.679536] x25: ffff8000118bbd38 x24: ffff000034a11000
    [   11.679540] x23: ffff00003490a100 x22: ffff000035064240
    [   11.679543] x21: ffff0000332a1014 x20: ffff0000339b8c00
    [   11.679547] x19: ffff8000118bbd38 x18: ffff000033df87e8
    [   11.679550] x17: 0000000060175def x16: 000000005f5f696e
    [   11.679554] x15: 00000520dfc4da1c x14: 000000000000015a
    [   11.679557] x13: 000000000000009f x12: 0000000000000001
    [   11.679560] x11: 0000000000000001 x10: 0000000000000001
    [   11.679564] x9 : 000000000000009f x8 : ffff0000332a101c
    [   11.679567] x7 : 0000000000000000 x6 : ffff0000332a101c
    [   11.679571] x5 : 000000000000001c x4 : 0000000000008000
    [   11.679574] x3 : ffff000034a12058 x2 : 0000000000000000
    [   11.679577] x1 : ffff8000118bbd38 x0 : 0000000000000000
    [   11.679582] Call trace:
    [   11.679595]  nl80211_send_chandef+0x178/0x188 [cfg80211]
    [   11.679608]  nl80211_ch_switch_notify.isra.0.constprop.0+0xec/0x180 [cfg80211]
    [   11.679621]  cfg80211_ch_switch_notify+0x80/0xb8 [cfg80211]
    [   11.679754]  rtw_cfg80211_ch_switch_notify+0xfc/0x138 [8192eu]
    [   11.679823]  rtw_chk_start_clnt_join+0x68/0x88 [8192eu]
    [   11.679877]  join_cmd_hdl+0x1ec/0x338 [8192eu]
    [   11.679930]  rtw_cmd_thread+0x390/0x3c8 [8192eu]
    [   11.679942]  kthread+0xf8/0x128
    [   11.679949]  ret_from_fork+0x10/0x30
    [   11.679953] ---[ end trace 662dec273b9122c6 ]---

With these changes both traps are eliminated at driver startup.

Fix #188