### PR TITLE
fix Kconfig compatibility for kernel v5.9

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,6 +1,6 @@
 config RTL8192EU
 	tristate "Realtek 8192E USB WiFi"
 	depends on USB
-	---help---
+	help
 	  Help message of RTL8192EU
 


### PR DESCRIPTION
With kernel v5.9, support for the "---help---" keyword in Kconfig has been removed (see torvalds/linux@f70f74d). This change corrects the help keyword in the Kconfig of this driver.