### PR TITLE
Github actions enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   fetchKernelData:
@@ -18,6 +18,7 @@ jobs:
     needs: fetchKernelData
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: 
         version: ${{fromJson(needs.fetchKernelData.outputs.matrix)}}
         #version: [4.9.248, 4.4.248]
@@ -31,11 +32,11 @@ jobs:
         KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${VERSION}/ | grep -A8 "Build for amd64\|Test amd64")
         ALL_DEB=$(echo "$KERNEL_URL_DETAILS" |  grep -m1 'all.deb' | cut -d '"' -f 2)
         KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic
-        wget ${KERNEL_URL}v${VERSION}/$(echo "$KERNEL_URL_DETAILS" | grep -m1 "amd64.deb" | cut -d '"' -f 2)
-        wget ${KERNEL_URL}v${VERSION}/$ALL_DEB
-        sudo dpkg -i *.deb
+        wget -nv ${KERNEL_URL}v${VERSION}/$(echo "$KERNEL_URL_DETAILS" | grep -m1 "amd64.deb" | cut -d '"' -f 2)
+        wget -nv ${KERNEL_URL}v${VERSION}/$ALL_DEB
+        sudo dpkg --force-all -i *.deb
         sudo wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/module.lds.S -O /usr/src/linux-headers-$KVER/scripts/module.lds
         sudo sed -i '$ d' /usr/src/linux-headers-$KVER/scripts/module.lds
         echo "KVER=$KVER" >> $GITHUB_ENV
     - name: build
-      run: make KVER=$KVER 
+      run: make KVER=$KVER


### PR DESCRIPTION

- Set fail-fast to false. https://kernel.ubuntu.com/~kernel-ppa/mainline ocacionaly has build errors and not allways .deb files are generated correctly for all kernel versions. The change allow to test all branches.
- Removed verbose to wget commands. Made easier read the build logs.
- Forced dpkg command to allow compilation if .deb installations fails due dependencies not needed for build.