### PR TITLE
Fix buils with kernel 5.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,24 +29,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        version: ${{fromJson(needs.commontasks.outputs.matrix)}}
-        #version: [4.9.248, 4.4.248]
+        kernel_version: ${{fromJson(needs.commontasks.outputs.matrix)}}
+        gcc_version: [9, 10, 11]
+        #kernel_version: [5.15-rc3,5.14.10]
     steps:
+    - name: Set up GCC
+      uses: egor-tensin/setup-gcc@v1
+      with:
+        version: ${{matrix.gcc_version }}
     - name: install deb packages
-      env: 
-        VERSION: ${{matrix.version }}
       run: |
         KERNEL_URL=https://kernel.ubuntu.com/~kernel-ppa/mainline/
-        KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${VERSION}/ | grep -A8 "Build for amd64\|Test amd64")
+        KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${{matrix.kernel_version}}/ | grep -A8 "Build for amd64\|Test amd64")
         ALL_DEB=$(echo "$KERNEL_URL_DETAILS" |  grep -m1 'all.deb' | cut -d '"' -f 2)
         AMD64_DEB=$(echo "$KERNEL_URL_DETAILS" | grep -m1 "amd64.deb" | cut -d '"' -f 2)
         [  -z "$ALL_DEB" ] && exit 1
         [  -z "$AMD64_DEB" ] && exit 2
-        wget -nv ${KERNEL_URL}v${VERSION}/$AMD64_DEB
-        wget -nv ${KERNEL_URL}v${VERSION}/$ALL_DEB
-        wget -nv http://mirrors.kernel.org/ubuntu/pool/main/g/glibc/libc6_2.33-0ubuntu5_amd64.deb
+        wget -nv ${KERNEL_URL}v${{matrix.kernel_version}}/$AMD64_DEB
+        wget -nv ${KERNEL_URL}v${{matrix.kernel_version}}/$ALL_DEB
+        wget -nv http://mirrors.kernel.org/ubuntu/pool/main/g/glibc/libc6_2.34-0ubuntu2_amd64.deb
         sudo dpkg --force-all -i *.deb
         echo "KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic" >> $GITHUB_ENV
     - uses: actions/checkout@v2
-    - name: build
-      run: make KVER=$KVER
+    - name: build kernel ${{ matrix.kernel_version }} - GCC ${{ matrix.gcc_version }}
+      run: make KVER=$KVER CC=cc

--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -778,13 +778,14 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
 	j = 0;
 
 	for (i = 0; i < mapLen; i++) {
-		if (i % 16 == 0)
+		if (i % 16 == 0) {
 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
 			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
 				, pEfuseHal->fakeEfuseInitMap[i]
 				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
 			);
 		}
+	}
 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
 
 out_free_buffer:

--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -15,9 +15,12 @@
 #define _RTW_BR_EXT_C_
 
 #ifdef __KERNEL__
+	#include <linux/version.h>
 	#include <linux/if_arp.h>
 	#include <net/ip.h>
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 	#include <net/ipx.h>
+#endif
 	#include <linux/atalk.h>
 	#include <linux/udp.h>
 	#include <linux/if_pppox.h>
@@ -168,7 +171,7 @@ static __inline__ void __nat25_generate_ipv4_network_addr(unsigned char *network
 	memcpy(networkAddr + 7, (unsigned char *)ipAddr, 4);
 }
 
-
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 static __inline__ void __nat25_generate_ipx_network_addr_with_node(unsigned char *networkAddr,
 		unsigned int *ipxNetAddr, unsigned char *ipxNodeAddr)
 {
@@ -200,7 +203,7 @@ static __inline__ void __nat25_generate_apple_network_addr(unsigned char *networ
 	memcpy(networkAddr + 1, (unsigned char *)network, 2);
 	networkAddr[3] = *node;
 }
-
+#endif
 
 static __inline__ void __nat25_generate_pppoe_network_addr(unsigned char *networkAddr,
 		unsigned char *ac_mac, unsigned short *sid)
@@ -888,7 +891,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 			return -1;
 		}
 	}
-
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 	/*---------------------------------------------------*/
 	/*         Handle IPX and Apple Talk frame          */
 	/*---------------------------------------------------*/
@@ -1109,7 +1112,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 
 		return -1;
 	}
-
+#endif
 	/*---------------------------------------------------*/
 	/*                Handle PPPoE frame                */
 	/*---------------------------------------------------*/

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -3193,10 +3193,14 @@ void rtw_drv_scan_by_self(_adapter *padapter, u8 reason)
 		#ifdef CONFIG_LAYER2_ROAMING
 		if (rtw_chk_roam_flags(padapter, RTW_ROAM_ACTIVE) && pmlmepriv->need_to_roam == _TRUE)
 			RTW_INFO(FUNC_ADPT_FMT" need to roam, don't care BusyTraffic\n", FUNC_ADPT_ARG(padapter));
-		else
-		#endif
+		else {
 			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
 			goto exit;
+		}
+		#else
+			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
+			goto exit;
+		#endif
 	}
 	else if (ssc_chk != SS_ALLOW)
 		goto exit;

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -258,7 +258,7 @@ void rtw_txpwr_init_regd(struct rf_ctl_t *rfctl)
 		);
 		if (rfctl->regd_name)
 			break;
-		/* fallthrough */
+		__attribute__((__fallthrough__));
 	default:
 		rfctl->regd_name = regd_str(TXPWR_LMT_WW);
 		RTW_PRINT("assign %s for default case\n", regd_str(TXPWR_LMT_WW));

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -3224,9 +3224,10 @@ void rtw_parse_sta_vendor_ie_8812(_adapter *adapter, struct sta_info *sta, u8 *t
 		goto exit;
 	else {
 		if(*(p+1) > 6 ) {
-			for(i=0; i<9;i++)
+			for(i=0; i<9;i++) {
 				RTW_INFO("p[%d]=0x%x",i,*(p+i) );
 				RTW_INFO("\n");
+			}
 			if(*(p+6) != 2)
 				goto exit;
 			

--- a/hal/hal_intf.c
+++ b/hal/hal_intf.c
@@ -1077,7 +1077,7 @@ s32 c2h_handler(_adapter *adapter, u8 id, u8 seq, u8 plen, u8 *payload)
 	case C2H_EXTEND:
 		sub_id = payload[0];
 		/* no handle, goto default */
-  /* fallthrough */
+  		__attribute__((__fallthrough__));
 
 	default:
 		if (phydm_c2H_content_parsing(adapter_to_phydm(adapter), id, plen, payload) != TRUE)

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2401,8 +2401,8 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
 	case NL80211_IFTYPE_P2P_CLIENT:
 		is_p2p = _TRUE;
+		__attribute__((__fallthrough__));
 	#endif
-  /* fallthrough */
 	case NL80211_IFTYPE_STATION:
 		networkType = Ndis802_11Infrastructure;
 
@@ -2426,8 +2426,8 @@ static int cfg80211_rtw_change_iface(struct wiphy *wiphy,
 	#if defined(CONFIG_P2P) && ((LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE))
 	case NL80211_IFTYPE_P2P_GO:
 		is_p2p = _TRUE;
+		__attribute__((__fallthrough__));
 	#endif
-  /* fallthrough */
 	case NL80211_IFTYPE_AP:
 		networkType = Ndis802_11APMode;
 


### PR DESCRIPTION
Remove IPX support from driver, set as obsolete in Jan 2018.
IPX is not supported by the linux kernel since v5.15-rc1 see https://github.com/torvalds/linux/commit/6c9b40844751ea30c72f7a2f92f4d704bc6b2927

Modified CI scripts to test different GCC versions.

Fix #243
Supersede #239