### PR TITLE
Cleanup memcpy warnings from 5.17

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -217,6 +217,14 @@ typedef void *timer_hdl_context;
 
 typedef unsigned long systime;
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
+/* Porting from linux kernel v5.15-rc1 48eab831ae8b9f7002a533fa4235eed63ea1f1a3 */
+static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
+{
+	ether_addr_copy(dev->dev_addr, addr);
+}
+#endif
+
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 22))
 /* Porting from linux kernel, for compatible with old kernel. */
 static inline unsigned char *skb_tail_pointer(const struct sk_buff *skb)

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -9720,7 +9720,7 @@ static int rtw_mp_efuse_set(struct net_device *dev,
 		rtw_hal_read_chip_info(padapter);
 		/* set mac addr*/
 		rtw_macaddr_cfg(adapter_mac_addr(padapter), get_hal_mac_addr(padapter));
-		memcpy(padapter->pnetdev->dev_addr, get_hal_mac_addr(padapter), ETH_ALEN); /* set mac addr to net_device */
+		eth_hw_addr_set(padapter->pnetdev, get_hal_mac_addr(padapter)); /* set mac addr to net_device */
 
 #ifdef CONFIG_P2P
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -404,8 +404,7 @@ int hostapd_mode_init(_adapter *padapter)
 	mac[4] = 0x11;
 	mac[5] = 0x12;
 
-	memcpy(pnetdev->dev_addr, mac, ETH_ALEN);
-
+	eth_hw_addr_set(pnetdev, mac);
 
 	rtw_netif_carrier_off(pnetdev);
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1243,7 +1243,7 @@ static int rtw_net_set_mac_address(struct net_device *pnetdev, void *addr)
 	}
 
 	memcpy(adapter_mac_addr(padapter), sa->sa_data, ETH_ALEN); /* set mac addr to adapter */
-	memcpy(pnetdev->dev_addr, sa->sa_data, ETH_ALEN); /* set mac addr to net_device */
+	eth_hw_addr_set(pnetdev, sa->sa_data);/* set mac addr to net_device */
 
 #if 0
 	if (rtw_is_hw_init_completed(padapter)) {
@@ -1689,7 +1689,7 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	/* alloc netdev name */
 	rtw_init_netdev_name(ndev, name);
 
-	memcpy(ndev->dev_addr, adapter_mac_addr(adapter), ETH_ALEN);
+	eth_hw_addr_set(ndev, adapter_mac_addr(adapter));
 
 	/* Tell the network stack we exist */
 
@@ -2646,7 +2646,7 @@ int _netdev_vir_if_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
-		memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+		eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
 	}
 #endif /*CONFIG_PLATFORM_INTEL_BYT*/
 
@@ -3395,7 +3395,7 @@ int _netdev_open(struct net_device *pnetdev)
 		rtw_mbid_camid_alloc(padapter, adapter_mac_addr(padapter));
 #endif
 		rtw_init_wifidirect_addrs(padapter, adapter_mac_addr(padapter), adapter_mac_addr(padapter));
-		memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+		eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
 #endif /* CONFIG_PLATFORM_INTEL_BYT */
 
 		rtw_clr_surprise_removed(padapter);

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1594,7 +1594,7 @@ int rtw_change_ifname(_adapter *padapter, const char *ifname)
 
 	rtw_init_netdev_name(pnetdev, ifname);
 
-	memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
+	eth_hw_addr_set(pnetdev, adapter_mac_addr(padapter));
 
 	if (rtnl_lock_needed)
 		ret = register_netdev(pnetdev);


### PR DESCRIPTION
Introduce eth_hw_addr_set from 5.15
Port https://github.com/torvalds/linux/commit/48eab831ae8b9f7002a533fa4235eed63ea1f1a3
Port https://github.com/torvalds/linux/commit/6ed178cb23ec7503dd354c02c0c9ef97a6b8b22a