### PR TITLE
Fix 5.18 compilation

### DIFF
--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -3042,7 +3042,6 @@ int storeAdaptorInfoFile(char *path, u8 *efuse_data)
 int retriveAdaptorInfoFile(char *path, u8 *efuse_data)
 {
 	int ret = _SUCCESS;
-	mm_segment_t oldfs;
 	struct file *fp;
 
 	if (path && efuse_data) {

--- a/core/rtw_ieee80211.c
+++ b/core/rtw_ieee80211.c
@@ -1496,7 +1496,6 @@ int rtw_get_mac_addr_intel(unsigned char *buf)
 	int ret = 0;
 	int i;
 	struct file *fp = NULL;
-	mm_segment_t oldfs;
 	unsigned char c_mac[MAC_ADDRESS_LEN];
 	char fname[] = "/config/wifi/mac.txt";
 	int jj, kk;

--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -1355,11 +1355,7 @@ exit:
 	pmptx->pallocated_buf = NULL;
 	pmptx->stop = 1;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	thread_exit(NULL);
-#else
-	kthread_thread_exit(NULL);
-#endif
 	return 0;
 }
 

--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -780,18 +780,18 @@ join_res:
 #define PORT_FMT "%u"
 #define PORT_ARG(x) ntohs(*((u16 *)(x)))
 
-extern __inline int is_multicast_mac_addr(const u8 *addr)
+static inline int is_multicast_mac_addr(const u8 *addr)
 {
 	return (addr[0] != 0xff) && (0x01 & addr[0]);
 }
 
-extern __inline int is_broadcast_mac_addr(const u8 *addr)
+static inline int is_broadcast_mac_addr(const u8 *addr)
 {
 	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
 		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
 }
 
-extern __inline int is_zero_mac_addr(const u8 *addr)
+static inline int is_zero_mac_addr(const u8 *addr)
 {
 	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
 		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -315,11 +315,7 @@ static __inline void thread_enter(char *name)
 	allow_signal(SIGTERM);
 #endif
 }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 void thread_exit(_completion *comp);
-#else
-void kthread_thread_exit(_completion *comp);
-#endif
 void _rtw_init_completion(_completion *comp);
 void _rtw_wait_for_comp_timeout(_completion *comp);
 void _rtw_wait_for_comp(_completion *comp);

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -11742,11 +11742,7 @@ thread_return lbk_thread(thread_context context)
 
 	ploopback->bstop = _TRUE;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	thread_exit(NULL);
-#else
-	kthread_thread_exit(NULL);
-#endif
 	return 0;
 }
 

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -34,6 +34,10 @@ inline struct proc_dir_entry *get_rtw_drv_proc(void)
 #define file_inode(file) ((file)->f_dentry->d_inode)
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17,0))
+#define PDE_DATA(inode) pde_data(inode)
+#endif
+
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0))
 #define PDE_DATA(inode) PDE((inode))->data
 #define proc_get_parent_data(inode) PDE((inode))->parent->data
@@ -211,11 +215,7 @@ const int drv_proc_hdls_num = sizeof(drv_proc_hdls) / sizeof(struct rtw_proc_hdl
 static int rtw_drv_proc_open(struct inode *inode, struct file *file)
 {
 	/* struct net_device *dev = proc_get_parent_data(inode); */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	ssize_t index = (ssize_t)PDE_DATA(inode);
-#else
-	ssize_t index = (ssize_t)inode->i_private;
-#endif
 	const struct rtw_proc_hdl *hdl = drv_proc_hdls + index;
 	void *private = NULL;
 
@@ -237,11 +237,7 @@ static int rtw_drv_proc_open(struct inode *inode, struct file *file)
 
 static ssize_t rtw_drv_proc_write(struct file *file, const char __user *buffer, size_t count, loff_t *pos)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	ssize_t index = (ssize_t)PDE_DATA(file_inode(file));
-#else
-	ssize_t index = (ssize_t)file_inode(file)->i_private;
-#endif
 	const struct rtw_proc_hdl *hdl = drv_proc_hdls + index;
 	ssize_t (*write)(struct file *, const char __user *, size_t, loff_t *, void *) = hdl->write;
 
@@ -4145,11 +4141,7 @@ const int adapter_proc_hdls_num = sizeof(adapter_proc_hdls) / sizeof(struct rtw_
 
 static int rtw_adapter_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	ssize_t index = (ssize_t)PDE_DATA(inode);
-#else
-	ssize_t index = (ssize_t)inode->i_private;
-#endif
 	const struct rtw_proc_hdl *hdl = adapter_proc_hdls + index;
 	void *private = proc_get_parent_data(inode);
 
@@ -4171,11 +4163,7 @@ static int rtw_adapter_proc_open(struct inode *inode, struct file *file)
 
 static ssize_t rtw_adapter_proc_write(struct file *file, const char __user *buffer, size_t count, loff_t *pos)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	ssize_t index = (ssize_t)PDE_DATA(file_inode(file));
-#else
-	ssize_t index = (ssize_t)file_inode(file)->i_private;
-#endif
 	const struct rtw_proc_hdl *hdl = adapter_proc_hdls + index;
 	ssize_t (*write)(struct file *, const char __user *, size_t, loff_t *, void *) = hdl->write;
 
@@ -4340,11 +4328,7 @@ const int odm_proc_hdls_num = sizeof(odm_proc_hdls) / sizeof(struct rtw_proc_hdl
 
 static int rtw_odm_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	ssize_t index = (ssize_t)PDE_DATA(inode);
-#else
-	ssize_t index = (ssize_t)inode->i_private;
-#endif
 	const struct rtw_proc_hdl *hdl = odm_proc_hdls + index;
 	void *private = proc_get_parent_data(inode);
 
@@ -4366,11 +4350,7 @@ static int rtw_odm_proc_open(struct inode *inode, struct file *file)
 
 static ssize_t rtw_odm_proc_write(struct file *file, const char __user *buffer, size_t count, loff_t *pos)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	ssize_t index = (ssize_t)PDE_DATA(file_inode(file));
-#else
-	ssize_t index = (ssize_t)file_inode(file)->i_private;
-#endif
 	const struct rtw_proc_hdl *hdl = odm_proc_hdls + index;
 	ssize_t (*write)(struct file *, const char __user *, size_t, loff_t *, void *) = hdl->write;
 
@@ -4507,11 +4487,7 @@ const int mcc_proc_hdls_num = sizeof(mcc_proc_hdls) / sizeof(struct rtw_proc_hdl
 
 static int rtw_mcc_proc_open(struct inode *inode, struct file *file)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	ssize_t index = (ssize_t)PDE_DATA(inode);
-#else
-	ssize_t index = (ssize_t)inode->i_private;
-#endif
 	const struct rtw_proc_hdl *hdl = mcc_proc_hdls + index;
 	void *private = proc_get_parent_data(inode);
 
@@ -4533,11 +4509,7 @@ static int rtw_mcc_proc_open(struct inode *inode, struct file *file)
 
 static ssize_t rtw_mcc_proc_write(struct file *file, const char __user *buffer, size_t count, loff_t *pos)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	ssize_t index = (ssize_t)PDE_DATA(file_inode(file));
-#else
-	ssize_t index = (ssize_t)file_inode(file)->i_private;
-#endif
 	const struct rtw_proc_hdl *hdl = mcc_proc_hdls + index;
 	ssize_t (*write)(struct file *, const char __user *, size_t, loff_t *, void *) = hdl->write;
 

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -872,20 +872,13 @@ u32 _rtw_down_sema(_sema *sema)
 
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 inline void thread_exit(_completion *comp)
-#else
-inline void kthread_thread_exit(_completion *comp)
-#endif
 {
-#ifdef PLATFORM_LINUX
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	complete_and_exit(comp, 0);
 #else
 	kthread_complete_and_exit(comp, 0);
 #endif
-#endif
-
 }
 
 inline void _rtw_init_completion(_completion *comp)


### PR DESCRIPTION
Rework 5.17 to made it more simple.
Fix 5.18 compilation after https://github.com/torvalds/linux/commit/967747bbc084b93b54e66f9047d342232314cd25 that removes mm_segment_t struct