### PR TITLE
GCC 11.2 needed for kernel>=5.17. Updated Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,9 @@ jobs:
         JSON=$(curl -s https://www.kernel.org/releases.json)
         VERSIONSARRAY=$(echo $JSON | jq -c '[.releases[] | {version: .version, moniker: .moniker} | select(.moniker != "linux-next") | .version]')
         echo ::set-output name=matrix::${VERSIONSARRAY}
-
   build:
     needs: commontasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix: 
@@ -33,11 +32,19 @@ jobs:
         gcc_version: [9, 10, 11]
         #kernel_version: [5.15-rc3,5.14.10]
     steps:
-    - name: Set up GCC
-      uses: egor-tensin/setup-gcc@v1
-      with:
-        version: ${{matrix.gcc_version }}
-    - name: install deb packages
+    - name: Check Versions
+      id: check_version
+      shell: bash {0}
+      run: |
+        echo ::set-output name=skip_build::False
+        dpkg --compare-versions "${{matrix.kernel_version}}" "ge" "5.17"
+        if [ $? -eq "0" ] && [ ${{matrix.gcc_version}} -lt 11 ];
+        then
+          echo "GCC version not compatible"
+          echo ::set-output name=skip_build::True
+        fi
+    - name: Download kernel packages
+      if: steps.check_version.outputs.skip_build == 'False'
       run: |
         KERNEL_URL=https://kernel.ubuntu.com/~kernel-ppa/mainline/
         KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${{matrix.kernel_version}}/ | grep -A8 "Build for amd64\|Test amd64")
@@ -47,9 +54,17 @@ jobs:
         [  -z "$AMD64_DEB" ] && exit 2
         wget -nv ${KERNEL_URL}v${{matrix.kernel_version}}/$AMD64_DEB
         wget -nv ${KERNEL_URL}v${{matrix.kernel_version}}/$ALL_DEB
-        wget -nv http://mirrors.edge.kernel.org/ubuntu/pool/main/g/glibc/libc6_2.34-0ubuntu3_amd64.deb
-        sudo dpkg --force-all -i *.deb
         echo "KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic" >> $GITHUB_ENV
+    - name: Set up GCC
+      if: steps.check_version.outputs.skip_build == 'False'
+      uses: egor-tensin/setup-gcc@v1
+      with:
+        version: ${{matrix.gcc_version }}
+    - name: install deb packages
+      if: steps.check_version.outputs.skip_build == 'False'
+      run: sudo dpkg --force-all -i *.deb
     - uses: actions/checkout@v2
+      if: steps.check_version.outputs.skip_build == 'False'
     - name: build kernel ${{ matrix.kernel_version }} - GCC ${{ matrix.gcc_version }}
+      if: steps.check_version.outputs.skip_build == 'False'
       run: make KVER=$KVER CC=cc


### PR DESCRIPTION
Last changes in the way to complile the linux kernel from https://kernel.ubuntu.com/~kernel-ppa/mainline/ cause the following error:
`gcc: error: unrecognized command line option ‘-mharden-sls=all’
`

This PR change the Ubuntu runner to align it to the ones used by Ubuntu kernel-ppa
`  The kernel was built by: gcc (Ubuntu 11.2.0-1)
`
Also the workaround for libc6 has been removed (already on 22.04 LTS), and kernel packages are downloaded first to allow fail fast.
