### PR TITLE
eth_hw_addr_set: use memcpy

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -221,7 +221,7 @@ typedef unsigned long systime;
 /* Porting from linux kernel v5.15-rc1 48eab831ae8b9f7002a533fa4235eed63ea1f1a3 */
 static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
 {
-	ether_addr_copy(dev->dev_addr, addr);
+	memcpy(dev->dev_addr, addr, ETH_ALEN);
 }
 #endif
 


### PR DESCRIPTION
eth_hw_addr_set() replaces memcpy() calls so we can't use ether_addr_copy()
which assumes both arguments are 2-bytes aligned.

https://github.com/torvalds/linux/commit/3f6cffb8604b537e3d7ea040d7f4368689638eaf
https://github.com/torvalds/linux/commit/adeef3e32146a8d2a73c399dc6f5d76a449131b1