### PR TITLE
Added compatibility with 5.17 & backported kernels

### DIFF
--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -34,13 +34,11 @@ inline struct proc_dir_entry *get_rtw_drv_proc(void)
 #define file_inode(file) ((file)->f_dentry->d_inode)
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17,0))
-#define PDE_DATA(inode) pde_data(inode)
-#endif
-
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0))
 #define PDE_DATA(inode) PDE((inode))->data
 #define proc_get_parent_data(inode) PDE((inode))->parent->data
+#elif !defined PDE_DATA
+#define PDE_DATA(inode) pde_data(inode)
 #endif
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 24))


### PR DESCRIPTION
CentOS and derived has backported PDE_DATA macro.
This change add compatibility  without use KERNEL_VERSION or RHEL_RELEASE_CODE