### PR TITLE
Fix update_beacon calls

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -102,7 +102,7 @@ static void update_BCNTIM(_adapter *padapter)
 		u8 *p, *dst_ie, *premainder_ie = NULL, *pbackup_remainder_ie = NULL;
 		uint offset, tmp_len, tim_ielen, tim_ie_offset, remainder_ielen;
 
-		p = rtw_get_ie(pie + _FIXED_IE_LENGTH_, WLAN_EID_DS_PARAMS, &tim_ielen, pnetwork_mlmeext->IELength - _FIXED_IE_LENGTH_);
+		p = rtw_get_ie(pie + _FIXED_IE_LENGTH_, WLAN_EID_TIM, &tim_ielen, pnetwork_mlmeext->IELength - _FIXED_IE_LENGTH_);
 		if (p != NULL && tim_ielen > 0) {
 			tim_ielen += 2;
 
@@ -599,7 +599,7 @@ void	expire_timeout_chk(_adapter *padapter)
 
 					/* to update bcn with tim_bitmap for this station */
 					rtw_tim_map_set(padapter, pstapriv->tim_bitmap, psta->cmn.aid);
-					update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE);
+					update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE);
 
 					if (!pmlmeext->active_keep_alive_check)
 						continue;
@@ -1817,7 +1817,7 @@ update_beacon:
 		}
 		#endif
 
-		update_beacon(pdvobj->padapters[i], WLAN_EID_DS_PARAMS, NULL, _FALSE);
+		update_beacon(pdvobj->padapters[i], WLAN_EID_TIM, NULL, _FALSE);
 	}
 
 	if (mlme_act != MLME_OPCH_SWITCH
@@ -2875,7 +2875,7 @@ u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
 	if ((rtw_tim_map_is_set(padapter, pstapriv->tim_bitmap, 0)) && (psta_bmc->sleepq_len > 0)) {
 		int tx_counts = 0;
 
-		_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _FALSE, "update TIM with TIB=1");
+		_update_beacon(padapter, WLAN_EID_TIM, NULL, _FALSE, "update TIM with TIB=1");
 
 		RTW_INFO("sleepq_len of bmc_sta = %d\n", psta_bmc->sleepq_len);
 
@@ -2925,7 +2925,7 @@ u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
 
 			if (update_tim == _TRUE) {
 				RTW_INFO("clear TIB\n");
-				_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE, "bmc sleepq and HIQ empty");
+				_update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE, "bmc sleepq and HIQ empty");
 			}
 		}
 	}
@@ -3261,7 +3261,7 @@ void _update_beacon(_adapter *padapter, u8 ie_id, u8 *oui, u8 tx, const char *ta
 	_enter_critical_bh(&pmlmepriv->bcn_update_lock, &irqL);
 
 	switch (ie_id) {
-	case WLAN_EID_DS_PARAMS:
+	case WLAN_EID_TIM:
 		update_BCNTIM(padapter);
 		break;
 
@@ -3738,7 +3738,7 @@ u8 bss_cap_update_on_sta_leave(_adapter *padapter, struct sta_info *psta)
 	if (rtw_tim_map_is_set(padapter, pstapriv->tim_bitmap, psta->cmn.aid)) {
 		rtw_tim_map_clear(padapter, pstapriv->tim_bitmap, psta->cmn.aid);
 		beacon_updated = _TRUE;
-		update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _FALSE);
+		update_beacon(padapter, WLAN_EID_TIM, NULL, _FALSE);
 	}
 
 	if (psta->no_short_preamble_set) {
@@ -5101,7 +5101,7 @@ void tx_beacon_handlder(struct dvobj_priv *pdvobj)
 		if (!check_fwstate(&padapter->mlmepriv, WIFI_OP_CH_SWITCHING)
 			&& !IS_CH_WAITING(adapter_to_rfctl(padapter))
 		) {
-			/*update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _FALSE);*/
+			/*update_beacon(padapter, WLAN_EID_TIM, NULL, _FALSE);*/
 			/*issue_beacon(padapter, 0);*/
 			send_beacon(padapter);
 		}

--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -4147,7 +4147,7 @@ static void rtw_chk_hi_queue_hdl(_adapter *padapter)
 			rtw_tim_map_clear(padapter, pstapriv->sta_dz_bitmap, 0);
 
 			if (update_tim == _TRUE)
-				_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE, "bmc sleepq and HIQ empty");
+				_update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE, "bmc sleepq and HIQ empty");
 		} else /* re check again */
 			rtw_chk_hi_queue_cmd(padapter);
 

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -4816,9 +4816,9 @@ sint xmitframe_enqueue_for_sleeping_sta(_adapter *padapter, struct xmit_frame *p
 			/* RTW_INFO_DUMP("enqueue, tim=", pstapriv->tim_bitmap, pstapriv->aid_bmp_len); */
 			if (update_tim == _TRUE) {
 				if (is_broadcast_mac_addr(pattrib->ra))
-					_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE, "buffer BC");
+					_update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE, "buffer BC");
 				else
-					_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE, "buffer MC");
+					_update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE, "buffer MC");
 			} else
 				chk_bmc_sleepq_cmd(padapter);
 
@@ -4885,7 +4885,7 @@ sint xmitframe_enqueue_for_sleeping_sta(_adapter *padapter, struct xmit_frame *p
 				if (update_tim == _TRUE) {
 					/* RTW_INFO("sleepq_len==1, update BCNTIM\n"); */
 					/* upate BCN for TIM IE */
-					_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE, "buffer UC");
+					_update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE, "buffer UC");
 				}
 			}
 
@@ -5170,11 +5170,11 @@ _exit:
 	if (update_mask) {
 		/* update_BCNTIM(padapter); */
 		if ((update_mask & (BIT(0) | BIT(1))) == (BIT(0) | BIT(1)))
-			_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE, "clear UC&BMC");
+			_update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE, "clear UC&BMC");
 		else if ((update_mask & BIT(1)) == BIT(1))
-			_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE, "clear BMC");
+			_update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE, "clear BMC");
 		else
-			_update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE, "clear UC");
+			_update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE, "clear UC");
 	}
 
 }
@@ -5252,7 +5252,7 @@ void xmit_delivery_enabled_frames(_adapter *padapter, struct sta_info *psta)
 			/* RTW_INFO_DUMP("update_BCNTIM, tim=", pstapriv->tim_bitmap, pstapriv->aid_bmp_len); */
 			/* upate BCN for TIM IE */
 			/* update_BCNTIM(padapter); */
-			update_beacon(padapter, WLAN_EID_DS_PARAMS, NULL, _TRUE);
+			update_beacon(padapter, WLAN_EID_TIM, NULL, _TRUE);
 			/* update_mask = BIT(0); */
 		}
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -8211,7 +8211,7 @@ u8 *rtw_cfg80211_construct_mesh_beacon_ies(struct wiphy *wiphy, _adapter *adapte
 	*c = WLAN_EID_TIM;
 	*(c + 1) = 4;
 	c += 6;
-	//c = rtw_set_ie(c, WLAN_EID_DS_PARAMS, 4, NULL, NULL);
+	//c = rtw_set_ie(c, WLAN_EID_TIM, 4, NULL, NULL);
 
 	/* Extended Supported Rates */
 	if (n_bitrates > 8)


### PR DESCRIPTION
Error introduced at 3555bdb25800fe9fb280c64663ab2e3a46762d63 
Changes based on https://github.com/torvalds/linux/commit/aaa0bc19facf31426ca57267edc681a42dbd1ee1
Also clean up validate_recv_ctrl_frame, based on https://github.com/torvalds/linux/commit/797afdf24872a087567b680402bde62b06697b42

Fix #275
