### PR TITLE
cfg80211_rtw_scan: fix NULL pointer dereference in Wi-Fi Direct logic

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2958,7 +2958,7 @@ static int cfg80211_rtw_scan(struct wiphy *wiphy
 #endif
 #ifdef CONFIG_P2P
 	if (pwdinfo->driver_interface == DRIVER_CFG80211) {
-		if (_rtw_memcmp(ssids->ssid, "DIRECT-", 7)
+		if (ssids && _rtw_memcmp(ssids->ssid, "DIRECT-", 7)
 			&& rtw_get_p2p_ie((u8 *)request->ie, request->ie_len, NULL, NULL)
 		) {
 			if (rtw_p2p_chk_state(pwdinfo, P2P_STATE_NONE))
@@ -3065,7 +3065,7 @@ bypass_p2p_chk:
 
 #ifdef CONFIG_P2P
 	if (pwdinfo->driver_interface == DRIVER_CFG80211) {
-		if (ssids->ssid != NULL
+		if (ssids
 			&& _rtw_memcmp(ssids->ssid, "DIRECT-", 7)
 			&& rtw_get_p2p_ie((u8 *)request->ie, request->ie_len, NULL, NULL)
 		) {


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/Mange/rtl8192eu-linux-driver/pull/298.

The aforementioned PR actually removes another check for `NULL`:

```c
if (params->pmkid != NULL) {
```

But I'm not sure if that should be reverted too. @kmlebedev any ideas?