### PR TITLE
fix netif_napi_add Linux 6.1/6.3 execution issue

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1674,9 +1674,9 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 
 #ifdef CONFIG_RTW_NAPI
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
-	netif_napi_add_weight(ndev, &adapter->napi, rtw_recv_napi_poll , RTL_NAPI_WEIGHT
+	netif_napi_add_weight(ndev, &adapter->napi, rtw_recv_napi_poll, RTL_NAPI_WEIGHT
 #else
-	netif_napi_add(ndev, &adapter->napi, rtw_recv_napi_poll
+	netif_napi_add(ndev, &adapter->napi, rtw_recv_napi_poll, RTL_NAPI_WEIGHT
 #endif
 	);
 #endif /* CONFIG_RTW_NAPI */

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1673,9 +1673,10 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	u8 rtnl_lock_needed = rtw_rtnl_lock_needed(dvobj);
 
 #ifdef CONFIG_RTW_NAPI
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
+	netif_napi_add_weight(ndev, &adapter->napi, rtw_recv_napi_poll , RTL_NAPI_WEIGHT
+#else
 	netif_napi_add(ndev, &adapter->napi, rtw_recv_napi_poll
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
-	, RTL_NAPI_WEIGHT
 #endif
 	);
 #endif /* CONFIG_RTW_NAPI */


### PR DESCRIPTION
I'm not by any means an Linux kernel expert or anything, but this seems to be correct way to fix compile issue on 6.1/6.3 kernels