### PR TITLE
Add LTS backport for eth_hw_addr_set_fix

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -219,10 +219,11 @@ typedef unsigned long systime;
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 /* Porting from linux kernel v5.15-rc1 48eab831ae8b9f7002a533fa4235eed63ea1f1a3 */
-static inline void eth_hw_addr_set(struct net_device *dev, const u8 *addr)
+static inline void rtw_eth_hw_addr_set(struct net_device *dev, const u8 *addr)
 {
 	memcpy(dev->dev_addr, addr, ETH_ALEN);
 }
+#define eth_hw_addr_set rtw_eth_hw_addr_set
 #endif
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 22))


### PR DESCRIPTION
eth_hw_addr_set has been backported to LTS kernels
Fix #324
