### PR TITLE
Avoid field-overflowing memcpy()

### DIFF
--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -4741,7 +4741,7 @@ unsigned int rtw_restructure_ht_ie(_adapter *padapter, u8 *in_ie, u8 *out_ie, ui
 	}
 
 	/* fill default supported_mcs_set */
-	memcpy(ht_capie.mcs.rx_mask, pmlmeext->default_supported_mcs_set, 16);
+	memcpy(&ht_capie.mcs, pmlmeext->default_supported_mcs_set, 16);
 
 	/* update default supported_mcs_set */
 	rtw_hal_get_hwreg(padapter, HW_VAR_RF_TYPE, (u8 *)(&rf_type));


### PR DESCRIPTION
Adjust memcpy() destination to be the named structure itself, rather than the first member, allowing memcpy() to correctly reason about the size.