### PR TITLE
Fix GLIBC_2.38 requirement for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,68 +3,68 @@ name: Build
 on: [pull_request]
 
 jobs:
-
   commontasks:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Avoid 0x0BDA
-      #Find devices that not use 0x0BDA instead of const USB_VENDOR_ID_REALTEK
-      run: grep -c -i "0x0BDA" os_dep/linux/usb_intf.c | grep -w 1
-    - name: Find duplicates
-      #Find devices that not use 0x0BDA instead of const USB_VENDOR_ID_REALTEK
-      run: grep -i "{USB_DEVICE(" os_dep/linux/usb_intf.c | cut -d ')' -f1 | sort | uniq -cd | wc -c | grep -w 0
-    - name: Get kernel matrix
-      id: set-matrix
-      run: |
-        JSON=$(curl -s https://www.kernel.org/releases.json)
-        VERSIONSARRAY=$(echo $JSON | jq -c '[.releases[] | {version: .version, moniker: .moniker} | select(.moniker != "linux-next") | .version]')
-        echo ::set-output name=matrix::${VERSIONSARRAY}
+      - uses: actions/checkout@v2
+      - name: Avoid 0x0BDA
+        #Find devices that not use 0x0BDA instead of const USB_VENDOR_ID_REALTEK
+        run: grep -c -i "0x0BDA" os_dep/linux/usb_intf.c | grep -w 1
+      - name: Find duplicates
+        #Find devices that not use 0x0BDA instead of const USB_VENDOR_ID_REALTEK
+        run: grep -i "{USB_DEVICE(" os_dep/linux/usb_intf.c | cut -d ')' -f1 | sort | uniq -cd | wc -c | grep -w 0
+      - name: Get kernel matrix
+        id: set-matrix
+        run: |
+          JSON=$(curl -s https://www.kernel.org/releases.json)
+          VERSIONSARRAY=$(echo $JSON | jq -c '[.releases[] | {version: .version, moniker: .moniker} | select(.moniker != "linux-next") | .version]')
+          echo ::set-output name=matrix::${VERSIONSARRAY}
   build:
     needs: commontasks
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         kernel_version: ${{fromJson(needs.commontasks.outputs.matrix)}}
         gcc_version: [9, 10, 12]
         # kernel_version: [6.1-rc1]
     steps:
-    - name: Check Versions
-      id: check_version
-      shell: bash {0}
-      run: |
-        echo ::set-output name=skip_build::False
-        dpkg --compare-versions "${{matrix.kernel_version}}" "ge" "5.15"
-        if [ $? -eq "0" ] && [ ${{matrix.gcc_version}} -lt 12 ];
-        then
-          echo "GCC version not compatible"
-          echo ::set-output name=skip_build::True
-        fi
-    - name: Download kernel packages
-      if: steps.check_version.outputs.skip_build == 'False'
-      run: |
-        KERNEL_URL=https://kernel.ubuntu.com/~kernel-ppa/mainline/
-        KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${{matrix.kernel_version}}/ | grep -A8 "Build for amd64\|Test amd64")
-        ALL_DEB=$(echo "$KERNEL_URL_DETAILS" |  grep -m1 'all.deb' | cut -d '"' -f 2)
-        AMD64_DEB=$(echo "$KERNEL_URL_DETAILS" | grep -m1 "amd64.deb" | cut -d '"' -f 2)
-        [  -z "$ALL_DEB" ] && exit 1
-        [  -z "$AMD64_DEB" ] && exit 2
-        wget -nv ${KERNEL_URL}v${{matrix.kernel_version}}/$AMD64_DEB
-        wget -nv ${KERNEL_URL}v${{matrix.kernel_version}}/$ALL_DEB
-        echo "KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic" >> $GITHUB_ENV
-    - name: Set up GCC
-      if: steps.check_version.outputs.skip_build == 'False'
-      uses: egor-tensin/setup-gcc@v1
-      with:
-        version: ${{matrix.gcc_version }}
-    - name: install deb packages
-      if: steps.check_version.outputs.skip_build == 'False'
-      run: sudo dpkg --force-all -i *.deb
-    - uses: actions/checkout@v2
-      if: steps.check_version.outputs.skip_build == 'False'
-    - name: build kernel ${{ matrix.kernel_version }} - GCC ${{ matrix.gcc_version }}
-      if: steps.check_version.outputs.skip_build == 'False'
-      run: make KVER=$KVER CC=cc
+      - name: Check Versions
+        id: check_version
+        shell: bash {0}
+        run: |
+          echo ::set-output name=skip_build::False
+          dpkg --compare-versions "${{matrix.kernel_version}}" "ge" "5.15"
+          if [ $? -eq "0" ] && [ ${{matrix.gcc_version}} -lt 12 ];
+          then
+            echo "GCC version not compatible"
+            echo ::set-output name=skip_build::True
+          fi
+      - name: Download kernel packages
+        if: steps.check_version.outputs.skip_build == 'False'
+        run: |
+          KERNEL_URL=https://kernel.ubuntu.com/~kernel-ppa/mainline/
+          KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${{matrix.kernel_version}}/ | grep -A8 "Build for amd64\|Test amd64")
+          ALL_DEB=$(echo "$KERNEL_URL_DETAILS" |  grep -m1 'all.deb' | cut -d '"' -f 2)
+          AMD64_DEB=$(echo "$KERNEL_URL_DETAILS" | grep -m1 "amd64.deb" | cut -d '"' -f 2)
+          [  -z "$ALL_DEB" ] && exit 1
+          [  -z "$AMD64_DEB" ] && exit 2
+          wget -nv ${KERNEL_URL}v${{matrix.kernel_version}}/$AMD64_DEB
+          wget -nv ${KERNEL_URL}v${{matrix.kernel_version}}/$ALL_DEB
+          wget -nv http://mirrors.kernel.org/ubuntu/pool/main/g/glibc/libc6_2.38-1ubuntu6_amd64.deb
+          echo "KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic" >> $GITHUB_ENV
+      - name: Set up GCC
+        if: steps.check_version.outputs.skip_build == 'False'
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: ${{matrix.gcc_version }}
+      - name: install deb packages
+        if: steps.check_version.outputs.skip_build == 'False'
+        run: sudo dpkg --force-all -i *.deb
+      - uses: actions/checkout@v2
+        if: steps.check_version.outputs.skip_build == 'False'
+      - name: build kernel ${{ matrix.kernel_version }} - GCC ${{ matrix.gcc_version }}
+        if: steps.check_version.outputs.skip_build == 'False'
+        run: make KVER=$KVER CC=cc


### PR DESCRIPTION
New builds need GLIBC_2.38, are based on Ubuntu 23