### PR TITLE
fix UBSAN: array-index-out-of-bounds

### DIFF
--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -310,7 +310,7 @@ struct ieee_param {
 		struct {
 			u32 len;
 			u8 reserved[32];
-			u8 data[0];
+			u8 data[];
 		} wpa_ie;
 		struct {
 			int command;
@@ -323,7 +323,7 @@ struct ieee_param {
 			u8 idx;
 			u8 seq[8]; /* sequence counter (set: RX, get: TX) */
 			u16 key_len;
-			u8 key[0];
+			u8 key[];
 		} crypt;
 #ifdef CONFIG_AP_MODE
 		struct {
@@ -335,7 +335,7 @@ struct ieee_param {
 		} add_sta;
 		struct {
 			u8	reserved[2];/* for set max_num_sta */
-			u8	buf[0];
+			u8	buf[];
 		} bcn_ie;
 #endif
 
@@ -346,7 +346,7 @@ struct ieee_param {
 struct ieee_param_ex {
 	u32 cmd;
 	u8 sta_addr[ETH_ALEN];
-	u8 data[0];
+	u8 data[];
 };
 
 struct sta_data {
@@ -711,7 +711,7 @@ extern struct rate_section_ent rates_by_sections[];
 struct ieee80211_info_element {
 	u8 id;
 	u8 len;
-	u8 data[0];
+	u8 data[];
 } __attribute__((packed));
 
 /*

--- a/include/wlan_bssdef.h
+++ b/include/wlan_bssdef.h
@@ -95,7 +95,7 @@ typedef struct _NDIS_802_11_FIXED_IEs {
 typedef struct _NDIS_802_11_VARIABLE_IEs {
 	UCHAR  ElementID;
 	UCHAR  Length;
-	UCHAR  data[1];
+	UCHAR  data[];
 } NDIS_802_11_VARIABLE_IEs, *PNDIS_802_11_VARIABLE_IEs;
 
 


### PR DESCRIPTION
Use "flexible array members"

See https://github.com/morrownr/8812au-20210629/issues/115
https://github.com/morrownr/8812au-20210629/commit/3356ab4bd4f2a4e1f9311655f3777a60730da5b7
https://github.com/torvalds/linux/commit/b47f6db34c296343a22c9db4ebdcc51d92301dbe
