### PR TITLE
Fixes 8192eu.o: error: objtool: mp_xmit_packet_thread+0x186: thread_exit() missing __noreturn

### DIFF
--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -315,7 +315,7 @@ static __inline void thread_enter(char *name)
 	allow_signal(SIGTERM);
 #endif
 }
-void thread_exit(_completion *comp);
+void __noreturn thread_exit(_completion *comp);
 void _rtw_init_completion(_completion *comp);
 void _rtw_wait_for_comp_timeout(_completion *comp);
 void _rtw_wait_for_comp(_completion *comp);

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -872,7 +872,7 @@ u32 _rtw_down_sema(_sema *sema)
 
 }
 
-inline void thread_exit(_completion *comp)
+__noreturn inline void thread_exit(_completion *comp)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	complete_and_exit(comp, 0);


### PR DESCRIPTION
In kernels 6.15.1 there are compilation errors that are fixed with this patch.