### PR TITLE
Fix: add extern mac_pton for Linux Kernel 7.0-RC1 compatibility

### DIFF
--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -1356,7 +1356,6 @@ exit:
 	pmptx->stop = 1;
 
 	thread_exit(NULL);
-	return 0;
 }
 
 void fill_txdesc_for_mp(PADAPTER padapter, u8 *ptxdesc)

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -315,7 +315,7 @@ static __inline void thread_enter(char *name)
 	allow_signal(SIGTERM);
 #endif
 }
-void thread_exit(_completion *comp);
+__noreturn void thread_exit(_completion *comp);
 void _rtw_init_completion(_completion *comp);
 void _rtw_wait_for_comp_timeout(_completion *comp);
 void _rtw_wait_for_comp(_completion *comp);

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -28,6 +28,7 @@
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
 extern int mac_pton(const char *s, u8 *addr);
 #endif
+#endif
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 27))
 #define  iwe_stream_add_event(a, b, c, d, e)  iwe_stream_add_event(b, c, d, e)

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -25,6 +25,7 @@
 #endif
 
 #ifdef __KERNEL__
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
 extern int mac_pton(const char *s, u8 *addr);
 #endif
 

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -14,12 +14,18 @@
  *****************************************************************************/
 #define _IOCTL_LINUX_C_
 
+
+#include <net/mac80211.h>
 #include <drv_types.h>
 #include <rtw_mp.h>
 #include <rtw_mp_ioctl.h>
 #include "../../hal/phydm/phydm_precomp.h"
 #ifdef RTW_HALMAC
 #include "../../hal/hal_halmac.h"
+#endif
+
+#ifdef __KERNEL__
+extern int mac_pton(const char *s, u8 *addr);
 #endif
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 27))

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -872,7 +872,7 @@ u32 _rtw_down_sema(_sema *sema)
 
 }
 
-inline void thread_exit(_completion *comp)
+__noreturn inline void thread_exit(_completion *comp)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	complete_and_exit(comp, 0);


### PR DESCRIPTION
Hello everyone! I've rebuilt the system using the new Linux Kernel 7.0-RC1. It turns out the driver fails to compile without a specific patch due to the implicit declaration of 'mac_pton'.

Here is the fix for the issue. After booting with the patched driver on the new kernel, no errors were detected. Tested on Arch Linux (Celeron G4920).
<img width="1138" height="343" alt="Снимок экрана_20260302_061506" src="https://github.com/user-attachments/assets/6bc6dc62-293f-46b3-8a3c-34a4c26e7742" />



[ioctl_linux.c](https://github.com/user-attachments/files/25671899/ioctl_linux.c)
FIX for Kernel 7.0 RC1!

![IMG_20260302_060941](https://github.com/user-attachments/assets/48dcf1c5-c346-44c9-88ec-dbc64fe26cdb)
![Screenshot_2026-03-02-06-03-21-133_com android settings](https://github.com/user-attachments/assets/59d54c5a-7eef-41b1-acb0-16b189c72966)
Working good! Max Speed 45-50Mbit\s