### PR TITLE
phydm: fix wrong enum type in phydm_clm_racing_ctrl signature

### DIFF
--- a/hal/phydm/phydm_ccx.c
+++ b/hal/phydm/phydm_ccx.c
@@ -1077,7 +1077,7 @@ void phydm_clm_racing_release(void *dm_void)
 	ccx->clm_app = CLM_BACKGROUND;
 }
 
-u8 phydm_clm_racing_ctrl(void *dm_void, enum phydm_nhm_level clm_lv)
+u8 phydm_clm_racing_ctrl(void *dm_void, enum phydm_clm_level clm_lv)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;


### PR DESCRIPTION
`phydm_clm_racing_ctrl()` declares its level parameter as `enum phydm_nhm_level`, evidently copy-pasted from `phydm_nhm_racing_ctrl()`. The function handles CLM (Channel Load Measurement) levels, and its only caller passes `clm_para_info.clm_lv`, which is `enum phydm_clm_level`.

This corrects the parameter type to `enum phydm_clm_level`.

`enum phydm_clm_level` and `enum phydm_nhm_level` are numerically identical (RELEASE=0, LV_1..LV_4=1..4, MAX_NUM=5), so there is no behavioral change — this is a type-correctness fix that resolves a `-Wenum-conversion` compiler warning.