### PR TITLE
Fix compatibility with Linux 6.9+ and 7.1+

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -23,6 +23,13 @@
 	#include <linux/atalk.h>
 	#include <linux/udp.h>
 	#include <linux/if_pppox.h>
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
+#define pppoe_tag_data(tag) ((char *)(tag) + sizeof(struct pppoe_tag))
+#define pppoe_hdr_tag(ph) ((struct pppoe_tag *)((char *)(ph) + sizeof(struct pppoe_hdr)))
+#else
+#define pppoe_tag_data(tag) ((tag)->tag_data)
+#define pppoe_hdr_tag(ph) ((ph)->tag)
+#endif
 #endif
 
 #if 1	/* rtw_wifi_driver */
@@ -88,7 +95,7 @@ static unsigned char *__nat25_find_pppoe_tag(struct pppoe_hdr *ph, unsigned shor
 	unsigned char *cur_ptr, *start_ptr;
 	unsigned short tagLen, tagType;
 
-	start_ptr = cur_ptr = (unsigned char *)ph->tag;
+	start_ptr = cur_ptr = (unsigned char *)pppoe_hdr_tag(ph);
 	while ((cur_ptr - start_ptr) < ntohs(ph->length)) {
 		/* prevent un-alignment access */
 		tagType = (unsigned short)((cur_ptr[0] << 8) + cur_ptr[1]);
@@ -114,9 +121,9 @@ static int __nat25_add_pppoe_tag(struct sk_buff *skb, struct pppoe_tag *tag)
 
 	skb_put(skb, data_len);
 	/* have a room for new tag */
-	memmove(((unsigned char *)ph->tag + data_len), (unsigned char *)ph->tag, ntohs(ph->length));
+	memmove(((unsigned char *)pppoe_hdr_tag(ph) + data_len), (unsigned char *)pppoe_hdr_tag(ph), ntohs(ph->length));
 	ph->length = htons(ntohs(ph->length) + data_len);
-	memcpy((unsigned char *)ph->tag, tag, data_len);
+	memcpy((unsigned char *)pppoe_hdr_tag(ph), tag, data_len);
 	return data_len;
 }
 
@@ -1143,8 +1150,8 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 								return -1;
 							}
 
-							memcpy(tag->tag_data + MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN,
-							       pOldTag->tag_data, old_tag_len);
+							memcpy(pppoe_tag_data(tag) + MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN,
+							       pppoe_tag_data(pOldTag), old_tag_len);
 
 							if (skb_pull_and_merge(skb, (unsigned char *)pOldTag, TAG_HDR_LEN + old_tag_len) < 0) {
 								DEBUG_ERR("call skb_pull_and_merge() failed in PADI/R packet!\n");
@@ -1157,9 +1164,9 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 						tag->tag_len = htons(MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN + old_tag_len);
 
 						/* insert the magic_code+client mac in relay tag */
-						pMagic = (unsigned short *)tag->tag_data;
+						pMagic = (unsigned short *)pppoe_tag_data(tag);
 						*pMagic = htons(MAGIC_CODE);
-						memcpy(tag->tag_data + MAGIC_CODE_LEN, skb->data + ETH_ALEN, ETH_ALEN);
+						memcpy(pppoe_tag_data(tag) + MAGIC_CODE_LEN, skb->data + ETH_ALEN, ETH_ALEN);
 
 						/* Add relay tag */
 						if (__nat25_add_pppoe_tag(skb, tag) < 0)
@@ -1220,14 +1227,14 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 						return -1;
 					}
 
-					pMagic = (unsigned short *)tag->tag_data;
+					pMagic = (unsigned short *)pppoe_tag_data(tag);
 					if (ntohs(*pMagic) != MAGIC_CODE) {
 						DEBUG_ERR("Can't find MAGIC_CODE in %s packet!\n",
 							(ph->code == PADO_CODE ? "PADO" : "PADS"));
 						return -1;
 					}
 
-					memcpy(skb->data, tag->tag_data + MAGIC_CODE_LEN, ETH_ALEN);
+					memcpy(skb->data, pppoe_tag_data(tag) + MAGIC_CODE_LEN, ETH_ALEN);
 
 					if (tagLen > MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN)
 						offset = TAG_HDR_LEN;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -18,6 +18,13 @@
 #include <hal_data.h>
 
 #ifdef CONFIG_IOCTL_CFG80211
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+#define RTW_WDEV_ARG struct wireless_dev *wdev
+#define RTW_WDEV_GET struct net_device *ndev = wdev->netdev
+#else
+#define RTW_WDEV_ARG struct net_device *ndev
+#define RTW_WDEV_GET
+#endif
 
 #ifndef DBG_RTW_CFG80211_STA_PARAM
 #define DBG_RTW_CFG80211_STA_PARAM 0
@@ -1700,7 +1707,7 @@ exit:
 	return ret;
 }
 
-static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
+static int cfg80211_rtw_add_key(struct wiphy *wiphy, RTW_WDEV_ARG
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	,int link_id
 #endif
@@ -1710,6 +1717,7 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
 #endif
 	, const u8 *mac_addr, struct key_params *params)
 {
+	RTW_WDEV_GET;
 	char *alg_name;
 	u32 param_len;
 	struct ieee_param *param = NULL;
@@ -1847,7 +1855,7 @@ addkey_end:
 
 }
 
-static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev
+static int cfg80211_rtw_get_key(struct wiphy *wiphy, RTW_WDEV_ARG
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	,int link_id
 #endif
@@ -1858,6 +1866,7 @@ static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev
 	, const u8 *mac_addr, void *cookie
 	, void (*callback)(void *cookie, struct key_params *))
 {
+	RTW_WDEV_GET;
 #define GET_KEY_PARAM_FMT_S " keyid=%d"
 #define GET_KEY_PARAM_ARG_S , keyid
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
@@ -2015,7 +2024,7 @@ exit:
 	return ret;
 }
 
-static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev,
+static int cfg80211_rtw_del_key(struct wiphy *wiphy, RTW_WDEV_ARG,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	int link_id,
 #endif
@@ -2025,6 +2034,7 @@ static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev,
 				u8 key_index, const u8 *mac_addr)
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) */
 {
+	RTW_WDEV_GET;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct security_priv *psecuritypriv = &padapter->securitypriv;
 
@@ -2091,12 +2101,13 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy,
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30))
 int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
-	struct net_device *ndev, 
+	RTW_WDEV_ARG, 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	int link_id,
 #endif	
 	u8 key_index)
 {
+	RTW_WDEV_GET;
 #define SET_DEF_KEY_PARAM_FMT " key_index=%d"
 #define SET_DEF_KEY_PARAM_ARG , key_index
 
@@ -2241,7 +2252,7 @@ static void rtw_cfg80211_fill_mesh_only_sta_info(struct mesh_plink_ent *plink, s
 #endif /* CONFIG_RTW_MESH */
 
 static int cfg80211_rtw_get_station(struct wiphy *wiphy,
-	struct net_device *ndev,
+	RTW_WDEV_ARG,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -2249,6 +2260,7 @@ static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 #endif
 	struct station_info *sinfo)
 {
+	RTW_WDEV_GET;
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
@@ -4401,7 +4413,11 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 		sinfo.filled = STATION_INFO_ASSOC_REQ_IES;
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+		cfg80211_new_sta(padapter->rtw_wdev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
+#else
 		cfg80211_new_sta(ndev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
+#endif
 	}
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */
 	channel = pmlmeext->cur_channel;
@@ -4447,7 +4463,11 @@ void rtw_cfg80211_indicate_sta_disassoc(_adapter *padapter, const u8 *da, unsign
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
 #if defined(RTW_USE_CFG80211_STA_EVENT) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	cfg80211_del_sta(padapter->rtw_wdev, da, GFP_ATOMIC);
+#else
 	cfg80211_del_sta(ndev, da, GFP_ATOMIC);
+#endif
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */
 	channel = pmlmeext->cur_channel;
 	freq = rtw_ch2freq(channel);
@@ -5368,7 +5388,7 @@ void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct statio
 #endif /* DBG_RTW_CFG80211_STA_PARAM */
 }
 
-static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_add_station(struct wiphy *wiphy, RTW_WDEV_ARG,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -5376,6 +5396,7 @@ static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct net_device *ndev
 #endif
 	struct station_parameters *params)
 {
+	RTW_WDEV_GET;
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 #if defined(CONFIG_TDLS) || defined(CONFIG_RTW_MESH)
@@ -5536,7 +5557,7 @@ exit:
 	return ret;
 }
 
-static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_del_station(struct wiphy *wiphy, RTW_WDEV_ARG,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
@@ -5546,6 +5567,7 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 #endif
 )
 {
+	RTW_WDEV_GET;
 	int ret = 0;
 	_irqL irqL;
 	_list	*phead, *plist;
@@ -5642,7 +5664,7 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 
 }
 
-static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_change_station(struct wiphy *wiphy, RTW_WDEV_ARG,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -5650,6 +5672,7 @@ static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *n
 #endif
 	struct station_parameters *params)
 {
+	RTW_WDEV_GET;
 #ifdef CONFIG_RTW_MESH
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct sta_priv *stapriv = &adapter->stapriv;
@@ -5796,9 +5819,10 @@ struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int id
 	return psta;
 }
 
-static int	cfg80211_rtw_dump_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_dump_station(struct wiphy *wiphy, RTW_WDEV_ARG,
 		int idx, u8 *mac, struct station_info *sinfo)
 {
+	RTW_WDEV_GET;
 #define DBG_DUMP_STATION 0
 
 	int ret = 0;


### PR DESCRIPTION
### Summary
This Pull Request fixes compilation failures of the out-of-tree **rtl8192eu-linux-driver** when compiled against modern Linux kernels, specifically Linux **6.9+** and **7.1+**.

### Root Cause
1. **PPPoE Flexible Array Members (Linux 6.9+):** The flexible array members of `struct pppoe_tag` and `struct pppoe_hdr` in `<uapi/linux/if_pppox.h>` were hidden behind `#ifndef __KERNEL__` guards in recent kernel versions, breaking direct member access (`tag->tag_data` and `ph->tag`) in kernel-space.
2. **cfg80211 callback signatures (Linux 7.1+):** The wireless configuration operations (in `struct cfg80211_ops`) and helper notification functions (`cfg80211_new_sta` and `cfg80211_del_sta`) were changed to take `struct wireless_dev *wdev` as an argument instead of `struct net_device *ndev`.

### Changes Made
- **PPPoE helper macros:** Added `pppoe_tag_data(tag)` and `pppoe_hdr_tag(ph)` macros in `core/rtw_br_ext.c` to compute offsets safely using `sizeof` when compiling on Linux >= 6.9.0, falling back to standard field access on older kernels.
- **cfg80211 clean macros:** Introduced `RTW_WDEV_ARG` and `RTW_WDEV_GET` macros in `os_dep/linux/ioctl_cfg80211.c` to handle the signature change cleanly without code duplication.
- **Notifiers update:** Updated the calls to `cfg80211_new_sta` and `cfg80211_del_sta` to use `padapter->rtw_wdev` on Linux >= 7.1.0.

### Compatibility
- Retains backwards compatibility with older LTS kernels (tested against Linux **6.6 LTS** and **6.12 LTS**).
- Compiles cleanly on intermediate versions (Linux **6.15** and **7.0**).

### Verification
- Successfully built the final `8192eu.ko` module against **Linux 7.1.3-cachyos** headers using LLVM/Clang without introducing new warnings.